### PR TITLE
feat: Improve reset password to work with out forms

### DIFF
--- a/flask_security/confirmable.py
+++ b/flask_security/confirmable.py
@@ -10,6 +10,8 @@
     :license: MIT, see LICENSE for more details.
 """
 
+import urllib.parse
+
 from flask import current_app as app
 from werkzeug.local import LocalProxy
 
@@ -38,6 +40,10 @@ def send_confirmation_instructions(user):
     """
 
     confirmation_link, token = generate_confirmation_link(user)
+    if _security.link_host:
+        # useful for testing when UI is separate from backend
+        link_parse = urllib.parse.urlsplit(confirmation_link)
+        confirmation_link = urllib.parse.urlunsplit(link_parse._replace(netloc = _security.link_host))
 
     send_mail(config_value('EMAIL_SUBJECT_CONFIRM'), user.email,
               'confirmation_instructions', user=user,

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -62,6 +62,8 @@ _default_config = {
     'POST_CONFIRM_VIEW': None,
     'POST_RESET_VIEW': None,
     'POST_CHANGE_VIEW': None,
+    'RESET_REDIRECT': None,  # non-form based password reset API
+    'LINK_HOST': None,  # Useful to specify host:port for email links for testing where UI and backend are separate
     'UNAUTHORIZED_VIEW': lambda: None,
     'FORGOT_PASSWORD_TEMPLATE': 'security/forgot_password.html',
     'LOGIN_USER_TEMPLATE': 'security/login_user.html',

--- a/flask_security/recoverable.py
+++ b/flask_security/recoverable.py
@@ -9,6 +9,8 @@
     :license: MIT, see LICENSE for more details.
 """
 
+import urllib.parse
+
 from flask import current_app as app
 from werkzeug.local import LocalProxy
 
@@ -31,6 +33,10 @@ def send_reset_password_instructions(user):
     reset_link = url_for_security(
         'reset_password', token=token, _external=True
     )
+    if _security.link_host:
+        # useful for testing when UI is separate from backend
+        link_parse = urllib.parse.urlsplit(reset_link)
+        reset_link = urllib.parse.urlunsplit(link_parse._replace(netloc = _security.link_host))
 
     if config_value('SEND_PASSWORD_RESET_EMAIL'):
         send_mail(config_value('EMAIL_SUBJECT_PASSWORD_RESET'), user.email,

--- a/flask_security/registerable.py
+++ b/flask_security/registerable.py
@@ -9,6 +9,8 @@
     :license: MIT, see LICENSE for more details.
 """
 
+import urllib.parse
+
 from flask import current_app as app
 from werkzeug.local import LocalProxy
 
@@ -31,6 +33,11 @@ def register_user(**kwargs):
 
     if _security.confirmable:
         confirmation_link, token = generate_confirmation_link(user)
+        if _security.link_host:
+            # useful for testing when UI is separate from backend
+            link_parse = urllib.parse.urlsplit(confirmation_link)
+            confirmation_link = urllib.parse.urlunsplit(link_parse._replace(netloc=_security.link_host))
+
         do_flash(*get_message('CONFIRM_REGISTRATION', email=user.email))
 
     user_registered.send(app._get_current_object(),


### PR DESCRIPTION
Change forgot password and reset password to work completely without any UI forms.
Added config variable RESET_REDIRECT that is used to transfer control to the UI for the various reset password workflows.

To help test when UI is separate from backed - added config LINK_HOST which can be used to specify a different host:port for redirect URLs.

Add email to standard json response.