### PR TITLE
Fix referrer loop in _get_unauthorized_view().

### DIFF
--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -53,7 +53,12 @@ def _get_unauthorized_view():
             except BuildError:
                 view = None
         utils.do_flash(*utils.get_message('UNAUTHORIZED'))
-        return redirect(view or request.referrer or '/')
+        redirect_to = '/'
+        if (request.referrer and
+                not request.referrer.split('?')[0].endswith(request.path)):
+            redirect_to = request.referrer
+
+        return redirect(view or redirect_to)
     abort(403)
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -134,6 +134,25 @@ def test_unauthorized_access(client, get_message):
     assert get_message('UNAUTHORIZED') in response.data
 
 
+def test_unauthorized_access_with_referrer(client, get_message):
+    authenticate(client, 'joe@lp.com')
+    response = client.get('/admin', headers={'referer': '/admin'})
+    assert response.headers['Location'] != '/admin'
+    client.get(response.headers['Location'])
+
+    response = client.get(
+        '/admin?a=b',
+        headers={'referer': 'http://localhost/admin?x=y'}
+    )
+    assert response.headers['Location'] == 'http://localhost/'
+    client.get(response.headers['Location'])
+
+    response = client.get('/admin',
+                          headers={'referer': '/admin'},
+                          follow_redirects=True)
+    assert response.data.count(get_message('UNAUTHORIZED')) == 1
+
+
 def test_roles_accepted(client):
     for user in ("matt@lp.com", "joe@lp.com"):
         authenticate(client, user)


### PR DESCRIPTION
_get_unauthorized_view() is blindly trying to redirect to the referrer,
without checking if we came from there in the first place. This change
avoids the loops that result from that, by redirecting to `/` if we just
came from the referrer.

A unit test is also provided.

Without this change, the end result is that the browser enters into a
redirect loop, until eventually it goes to the correct place (I haven't
figured out how many; in production we've seen 10s, but in the provided
unit test it only happened 3 times). It also results in multiple
flash messages being printed once the final page is loaded.