### PR TITLE
Fix timing attack on login form

### DIFF
--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -20,7 +20,7 @@ from wtforms import BooleanField, Field, HiddenField, PasswordField, \
     StringField, SubmitField, ValidationError, validators
 
 from .confirmable import requires_confirmation
-from .utils import _, _datastore, config_value, get_message, \
+from .utils import _, _datastore, config_value, get_message, hash_password, \
     localize_callback, url_for_security, validate_redirect_url, \
     verify_and_update_password
 
@@ -234,9 +234,13 @@ class LoginForm(Form, NextFormMixin):
 
         if self.user is None:
             self.email.errors.append(get_message('USER_DOES_NOT_EXIST')[0])
+            # Reduce timing variation between existing and non-existung users
+            hash_password(self.password.data)
             return False
         if not self.user.password:
             self.password.errors.append(get_message('PASSWORD_NOT_SET')[0])
+            # Reduce timing variation between existing and non-existung users
+            hash_password(self.password.data)
             return False
         if not verify_and_update_password(self.password.data, self.user):
             self.password.errors.append(get_message('INVALID_PASSWORD')[0])


### PR DESCRIPTION
As detailed in #357 the time it takes to process a login request is
considerably less if the user specified doesn't exist than if the
password is incorrect. This can be used as a user enumeration attack,
even if the login error messages were customized to avoid this.

I fixed it by increasing the response time of a non-existing user
request by hashing the given password anyway (if using good
password hashing algorithm this is what takes a relatively
large amount of time and makes the attack possibly).

closes #357