### PR TITLE
Remove automatic login on email confirmation (opr #662)

### DIFF
--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -231,7 +231,6 @@ def confirm_email(token):
 
     if user != current_user:
         logout_user()
-        login_user(user)
 
     if confirm_user(user):
         after_this_request(_commit)
@@ -242,7 +241,7 @@ def confirm_email(token):
     do_flash(*get_message(msg))
 
     return redirect(get_url(_security.post_confirm_view) or
-                    get_url(_security.post_login_view))
+                    get_url(_security.login_url))
 
 
 @anonymous_user_required
@@ -294,9 +293,8 @@ def reset_password(token):
         after_this_request(_commit)
         update_password(user, form.password.data)
         do_flash(*get_message('PASSWORD_RESET'))
-        login_user(user)
         return redirect(get_url(_security.post_reset_view) or
-                        get_url(_security.post_login_view))
+                        get_url(_security.login_url))
 
     return _security.render_template(
         config_value('RESET_PASSWORD_TEMPLATE'),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,6 +120,14 @@ def app(request):
     def post_register():
         return render_template('index.html', content='Post Register')
 
+    @app.route('/post_confirm')
+    def post_confirm():
+        return render_template('index.html', content='Post Confirm')
+
+    @app.route('/post_reset')
+    def post_reset():
+        return render_template('index.html', content='Post Reset')
+
     @app.route('/admin')
     @roles_required('admin')
     def admin():

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -189,7 +189,37 @@ def test_confirmation_different_user_when_logged_in(client, get_message):
 
     response = client.get('/confirm/' + token2, follow_redirects=True)
     assert get_message('EMAIL_CONFIRMED') in response.data
-    assert b'Hello lady@lp.com' in response.data
+    assert b'Hello lady@lp.com' not in response.data
+    assert b'Hello dude@lp.com' not in response.data
+
+
+@pytest.mark.registerable()
+def test_confirm_redirect(client, get_message):
+    with capture_registrations() as registrations:
+        data = dict(email='jane@lp.com', password='password', next='')
+        client.post('/register', data=data, follow_redirects=True)
+
+    token = registrations[0]['confirm_token']
+
+    response = client.get('/confirm/' + token)
+    assert 'location' in response.headers
+    assert '/login' in response.location
+
+    response = client.get(response.location)
+    assert get_message('EMAIL_CONFIRMED') in response.data
+
+
+@pytest.mark.registerable()
+@pytest.mark.settings(post_confirm_view='/post_confirm')
+def test_confirm_redirect_to_post_confirm(client, get_message):
+    with capture_registrations() as registrations:
+        data = dict(email='john@lp.com', password='password', next='')
+        client.post('/register', data=data, follow_redirects=True)
+
+    token = registrations[0]['confirm_token']
+
+    response = client.get('/confirm/' + token, follow_redirects=True)
+    assert b'Post Confirm' in response.data
 
 
 @pytest.mark.registerable()

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -69,6 +69,7 @@ def test_recoverable_flag(app, client, get_message):
 
     assert get_message('PASSWORD_RESET') in response.data
     assert len(recorded_resets) == 1
+    assert b'Hello joe@lp.com' not in response.data
 
     logout(client)
 
@@ -208,6 +209,46 @@ def test_used_reset_token(client, get_message):
 
     msg = get_message('INVALID_RESET_PASSWORD_TOKEN')
     assert msg in response2.data
+
+
+def test_reset_token_redirect(client, get_message):
+    with capture_reset_password_requests() as requests:
+        client.post(
+            '/reset',
+            data=dict(
+                email='joe@lp.com'),
+            follow_redirects=True)
+
+    token = requests[0]['token']
+
+    response = client.post('/reset/' + token, data={
+        'password': 'newpassword',
+        'password_confirm': 'newpassword'
+    })
+
+    assert 'location' in response.headers
+    assert '/login' in response.location
+
+    response = client.get(response.location)
+    assert get_message('PASSWORD_RESET') in response.data
+
+
+@pytest.mark.settings(post_reset_view='/post_reset')
+def test_reset_token_redirect_to_post_reset(client, get_message):
+    with capture_reset_password_requests() as requests:
+        client.post(
+            '/reset',
+            data=dict(
+                email='joe@lp.com'),
+            follow_redirects=True)
+
+    token = requests[0]['token']
+
+    response = client.post('/reset/' + token, data={
+        'password': 'newpassword',
+        'password_confirm': 'newpassword'
+    }, follow_redirects=True)
+    assert b'Post Reset' in response.data
 
 
 def test_reset_passwordless_user(client, get_message):


### PR DESCRIPTION
* Successful password reset redirects to login view by default.

* Successful email confirmation redirects to login view by default.

* Updated password reset tests to check user doesn't get 
  logged in automatically.  (closes #662)

* Added tests to test redirections on password reset 
  and email confirmation.