### PR TITLE
Fix case where sqlachemy db driver raises exception

### DIFF
--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -241,14 +241,20 @@ class SQLAlchemyUserDatastore(SQLAlchemyDatastore, UserDatastore):
 
     def get_user(self, identifier):
         from sqlalchemy import func as alchemyFn
+        from sqlalchemy.exc import DataError
+
         user_model_query = self.user_model.query
         if hasattr(self.user_model, 'roles'):
             from sqlalchemy.orm import joinedload
             user_model_query = user_model_query.options(joinedload('roles'))
 
-        rv = self.user_model.query.get(identifier)
-        if rv is not None:
-            return rv
+        try:
+            rv = user_model_query.get(identifier)
+            if rv is not None:
+                return rv
+        except DataError:
+            # This can happen if trying a string against a numeric column
+            pass
 
         # Not PK - iterate through other attributes and look for 'identifier'
         for attr in get_identity_attributes():
@@ -256,9 +262,12 @@ class SQLAlchemyUserDatastore(SQLAlchemyDatastore, UserDatastore):
             # which isn't what we want.
             query = alchemyFn.lower(getattr(self.user_model, attr)) \
                 == alchemyFn.lower(identifier)
-            rv = user_model_query.filter(query).first()
-            if rv is not None:
-                return rv
+            try:
+                rv = user_model_query.filter(query).first()
+                if rv is not None:
+                    return rv
+            except DataError:
+                pass
 
     def find_user(self, **kwargs):
         query = self.user_model.query


### PR DESCRIPTION
If query a numeric column with a string value, some drivers (pyscopg) will throw
a DataError. This is similar fix to mongo, peewee, pony datastores.