### PR TITLE
bugfix(datastore) Fix get_user for various DBs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,9 @@ tests_require = [
     'mongomock>=3.14.0',
     'msgcheck>=2.9',
     'pony>=0.7.4',
+    'psycopg2>=2.7.4',
     'pydocstyle>=1.0.0',
+    'pymysql>=0.9.3',
     'pytest-cache>=1.0',
     'pytest-cov>=2.4.0',
     'pytest-flakes>=1.0.1',
@@ -34,6 +36,7 @@ tests_require = [
     'pytest-pep8>=1.0.6',
     'pytest>=3.3.0',
     'sqlalchemy>=1.1.0',
+    'sqlalchemy-utils>=0.33.0',
     'werkzeug>=0.12.2'
 ]
 

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -82,9 +82,14 @@ def test_activate_returns_false_if_already_true():
 
 
 def test_get_user(app, datastore):
+    # The order of identity attributes is important for testing.
+    # drivers like psycopg2 will abort the transaction if they throw an
+    # error and not continue on so we want to check that case of passing in
+    # a string for a numeric field and being able to move onto the next
+    # column.
     init_app_with_options(app, datastore, **{
-        'SECURITY_USER_IDENTITY_ATTRIBUTES': ('email', 'username',
-                                              'security_number')
+        'SECURITY_USER_IDENTITY_ATTRIBUTES': ('email', 'security_number',
+                                              'username')
     })
 
     with app.app_context():


### PR DESCRIPTION
DB drivers vary in how strict they are. For example
postgres+pyscopg2 throws errors if you attempt to lower(integer) or
compare a string field with an integer field.
Furthermore, when pyscopg2 throws an internal error like that, it
aborts the transaction - so you can't just try another query.

To solve this - in get_user we check for compatibility of types using
metadata that the ORM provides. This isn't trying to be completely
general - just looking at numeric and non-numeric types - on the
presumption that we would have unique user attributes on things like
dates, boolean, etc!.

To enable testing, added an option to pytest to specify a real DB
url to replace the default sqlite. This required a bit of refactoring
and realized that we really shouldn't be passing in fixtures to
the datastore() fixture since that meant all 5 datastores would be
instantiated EVERY time - which for a real DB was a performance issue.

With this addition - tested Sqlalchemy, peewee, pony with sqlite,
postgres, mysql.