### PR TITLE
feature - Support Json/Single-Page-Applications

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -87,6 +87,20 @@ Core
                                          ``500``
 ``VERIFY_HASH_CACHE_TTL``                Time to live for password check cache entries.
                                          Defaults to ``300`` (5 minutes)
+``SECURITY_REDIRECT_BEHAVIOR``           Passwordless login, confirmation, and
+                                         reset password have GET endpoints that validate
+                                         the passed token and redirect to an action form.
+                                         For Single-Page-Applications style UIs which need
+                                         to control their own internal URL routing these redirects
+                                         need to not contain forms, but contain relevant information
+                                         as query parameters. Setting this to ``spa`` will enable
+                                         that behavior. Defaults to ``None`` which is existing
+                                         html-style form redirects.
+``SECURITY_REDIRECT_HOST``               Mostly for development purposes, the UI is often developed
+                                         separately and is running on a different port than the
+                                         Flask application. In order to test redirects, the `netloc`
+                                         of the redirect URL needs to be rewritten. Setting this
+                                         to e.g. `localhost:8080` does that. Defaults to ``None``
 ======================================== =======================================
 
 
@@ -117,8 +131,10 @@ URLs and Views
                                 confirmation error occurs. This value can be set
                                 to a URL or an endpoint name. If this value is
                                 ``None``, the user is presented the default view
-                                to resend a confirmation link. Defaults to
-                                ``None``.
+                                to resend a confirmation link.
+                                In the case of ``SECURITY_REDIRECT_BEHAVIOR`` == ``spa``
+                                query params in the redirect will contain the error.
+                                Defaults to``None``.
 ``SECURITY_POST_REGISTER_VIEW`` Specifies the view to redirect to after a user
                                 successfully registers. This value can be set to
                                 a URL or an endpoint name. If this value is
@@ -148,6 +164,21 @@ URLs and Views
                                 not have permission to access. If this value is
                                 ``None``, the user is presented with a default
                                 HTTP 403 response. Defaults to ``None``.
+``SECURITY_RESET_VIEW``         Specifies the view/URL to redirect to after a GET
+                                reset-password link. This is only valid if
+                                ``SECURITY_REDIRECT_BEHAVIOR`` == ``spa``. Query params
+                                in the redirect will contain the token and email.
+                                Defaults to ``None``
+``SECURITY_RESET_ERROR_VIEW``   Specifies the view/URL to redirect to after a GET
+                                reset-password link when there is an error. This is only valid if
+                                ``SECURITY_REDIRECT_BEHAVIOR`` == ``spa``. Query params
+                                in the redirect will contain the error.
+                                Defaults to ``None``
+``SECURITY_LOGIN_ERROR_VIEW``   Specifies the view/URL to redirect to after a GET
+                                passwordless link when there is an error. This is only valid if
+                                ``SECURITY_REDIRECT_BEHAVIOR`` == ``spa``. Query params
+                                in the redirect will contain the error.
+                                Defaults to ``None``
 =============================== ================================================
 
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2,12 +2,22 @@ openapi: 3.0.0
 info:
   description: |
     Default API for Flask-Security.
-    N.B. This is preliminary.
+    
+    __N.B. This is preliminary.__
+    
     Since Flask-Security is middleware, with many possible configurations this is a
     guide to how the APIs will behave using standard defaults.
+    
+    _Be aware that the current renderer is great! but has some limitations._ 
+    In particular
+    it can't represent both form input and JSON input - but all APIs take both. Also
+    it currently doesn't render 'examples' correctly.
+    
+    You can download the latest spec from: https://github.com/jwag956/flask-security/blob/master/docs/openapi.yaml
   version: 1.0.0
   title: "Flask-Security External API"
   contact:
+    name: Flask-Security-Too
     url: https://github.com/jwag956/flask-security
   license:
     name: MIT
@@ -22,7 +32,7 @@ paths:
           content:
             text/html:
               schema:
-                example: render_template(config_value('LOGIN_USER_TEMPLATE')
+                example: render_template(cv('LOGIN_USER_TEMPLATE')
     post:
       summary: Login to application
       description: Supports both json and form request types
@@ -52,17 +62,17 @@ paths:
             text/html:
               schema:
                 description: Unsuccessful login
-                example: render_template(config_value('LOGIN_USER_TEMPLATE') with error values
+                example: render_template(cv('LOGIN_USER_TEMPLATE') with error values
         302:
           description: >
-            Successful login with form data body.
+            Success or failure with form data body.
             redirect('next') or redirect(config_value('POST_LOGIN_VIEW'))
           headers:
             Location:
               description: redirect
               schema:
                 type: string
-                example: redirect(config_value('POST_LOGIN_VIEW'))
+                example: redirect(cv('POST_LOGIN_VIEW'))
         400:
           description: Errors while validating login
           content:
@@ -74,13 +84,12 @@ paths:
       summary: Log out current user
       responses:
         302:
-          description: >
-            Successful logout
-            redirect(config_value('POST_LOGOUT_VIEW'))
+          description: Successful logout
           headers:
             Location:
+              description: redirect(cv('POST_LOGOUT_VIEW'))
               schema:
-                example: redirect(config_value('POST_LOGOUT_VIEW'))
+                example: redirect(cv('POST_LOGOUT_VIEW'))
     post:
       summary: Log out current user
       responses:
@@ -109,7 +118,7 @@ paths:
           content:
             text/html:
               schema:
-                example: render_template(config_value('REGISTER_USER_TEMPLATE')
+                example: render_template(cv('REGISTER_USER_TEMPLATE')
     post:
       summary: Register with application
       description: Supports both json and form request types
@@ -140,23 +149,112 @@ paths:
             text/html:
               schema:
                 description: Unsuccessful registration
-                example: render_template(config_value('REGISTER_USER_TEMPLATE') with error values
+                example: render_template(cv('REGISTER_USER_TEMPLATE') with error values
         302:
           description: >
             Successful registration with form data body.
-            redirect('next') or redirect(config_value('POST_REGISTER_VIEW'))
           headers:
             Location:
-              description: redirect
+              description: redirect to cv('next') or cv('POST_REGISTER_VIEW')
               schema:
                 type: string
-                example: redirect(config_value('POST_REGISTER_VIEW'))
         400:
           description: Errors while validating registration form
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/DefaultJsonErrorResponse"  
+  /reset/{token}:
+    parameters:
+      - name: token
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Request to reset password.
+      description: >
+        This is the result of getting a reset-password link and is usually
+        the result of clicking the link from a reset-password email.
+        If cv('REDIRECT_BEHAVIOR') == 'spa' then a 302 is always returned.
+      responses:
+        200:
+          description: Reset password form
+          content:
+            text/html:
+              schema:
+                example: render_template(cv('RESET_PASSWORD_TEMPLATE'))
+        302:
+          description: >
+            Redirects depending on success/error and whether 
+            cv('REDIRECT_BEHAVIOR') == 'spa'.
+          headers:
+            Location:
+              description: |
+                On spa-success: cv('RESET_VIEW')?token={token}&email={email}
+                
+                On spa-error-expired: cv('RESET_ERROR_VIEW')?error={msg}&email={email}
+                
+                On spa-error-invalid-token: cv('RESET_ERROR_VIEW')?error={msg}
+                
+                On default-error: redirect(cv('FORGOT_PASSWORD'))
+              schema:
+                type: string
+              examples:
+                spa-success:
+                  value: cv('RESET_VIEW')?token={token}&email={email}
+                spa-error-expired:
+                  value: cv('RESET_ERROR_VIEW')?error={msg}&email={email}
+                spa-error-invalid-token:
+                  value: cv('RESET_ERROR_VIEW')?error={msg}
+                default-error:
+                  value: redirect(cv('FORGOT_PASSWORD'))
+    post:
+      summary: Reset password.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ResetPassword"
+          application/x-www-form-urlencoded:
+            schema:             
+              $ref: "#/components/schemas/ResetPassword"
+      responses:
+        200:
+          description: Reset response.
+          content:
+            text/html:
+              schema:
+                description: Reset form validation error.
+                example: render_template(cv('RESET_PASSWORD_TEMPLATE') with error values
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DefaultJsonResponse"
+        302:
+          description: Password has been reset or validation error (non-json)
+          headers:
+            Location:
+              description: |
+                On success: redirect(cv('POST_RESET_VIEW')) or
+                    redirect(cv('POST_LOGIN_VIEW'))
+                    
+                On invalid/expired token: redirect(cv('FORGOT_PASSWORD'))
+              schema:
+                type: string
+              examples:
+                success:
+                  value: redirect(cv('POST_RESET_VIEW')) or
+                    redirect(cv('POST_LOGIN_VIEW'))
+                invalid/expired-token:
+                  value: redirect(cv('FORGOT_PASSWORD'))
+        400:
+          description: Errors while validating form
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DefaultJsonErrorResponse" 
+          
 components:
   schemas:
     Login:
@@ -183,7 +281,7 @@ components:
           type: object
           required: [id]
           description: >
-            By default just 'id' and 'authentication_token' are returned. However by overriding User::get_security_payload() any attributes of the User model can be returned.
+            By default just 'id' and 'authentication_token' are returned. However by overriding _User::get_security_payload()_ any attributes of the User model can be returned.
           properties:
             id:
               type: integer
@@ -216,7 +314,7 @@ components:
                   type: array
                   items:
                     type: string
-                    example: Email requires confirmation.
+                    example: Email issues.
                     description: Error message (localized)
     Register:
       type: object
@@ -250,5 +348,15 @@ components:
           type: string
           description: >
             Redirect URL. Overrides POST_REGISTER_VIEW
+    ResetPassword:
+      type: object
+      required: [password, password_confirm]
+      properties:
+        password:
+          type: string
+          description: Password
+        password_confirm:
+          type: string
+          description: Password - again
 
     

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -79,6 +79,11 @@ _default_config = {
     'POST_RESET_VIEW': None,
     'POST_CHANGE_VIEW': None,
     'UNAUTHORIZED_VIEW': None,
+    'RESET_ERROR_VIEW': None,
+    'RESET_VIEW': None,
+    'LOGIN_ERROR_VIEW': None,
+    'REDIRECT_HOST': None,
+    'REDIRECT_BEHAVIOR': None,
     'FORGOT_PASSWORD_TEMPLATE': 'security/forgot_password.html',
     'LOGIN_USER_TEMPLATE': 'security/login_user.html',
     'REGISTER_USER_TEMPLATE': 'security/register_user.html',
@@ -430,6 +435,13 @@ class UserMixin(BaseUserMixin):
     def get_security_payload(self):
         """Serialize user object as response payload."""
         return {'id': str(self.id)}
+
+    def get_redirect_qparams(self, existing=None):
+        """Return user info that will be added to redirect query params."""
+        if not existing:
+            existing = {}
+        existing.update({'email': self.email})
+        return existing
 
     def verify_and_update_password(self, password):
         """Verify and update user password using configured hash."""

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = -xrs --cov flask_security --cov-report term-missing --pep8 --flakes --cache-clear
+pep8maxlinelength = 120

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,9 @@ def app(request):
     app.config['SECURITY_PASSWORD_SALT'] = 'salty'
     # Make this plaintext for most tests - reduces unit test time by 50%
     app.config['SECURITY_PASSWORD_HASH'] = 'plaintext'
+    # Make this hex_md5 for token tests
+    app.config['SECURITY_HASHING_SCHEMES'] = ['hex_md5']
+    app.config['SECURITY_DEPRECATED_HASHING_SCHEMES'] = []
 
     for opt in ['changeable', 'recoverable', 'registerable',
                 'trackable', 'passwordless', 'confirmable']:

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -16,7 +16,13 @@ from flask_security.core import UserMixin
 from flask_security.forms import LoginForm
 from flask_security.signals import password_reset, \
     reset_password_instructions_sent
-from flask_security.utils import capture_reset_password_requests, string_types
+from flask_security.utils import capture_flashes,\
+    capture_reset_password_requests, string_types
+
+try:
+    from urlparse import parse_qsl, urlsplit
+except ImportError:  # pragma: no cover
+    from urllib.parse import parse_qsl, urlsplit
 
 pytestmark = pytest.mark.recoverable()
 
@@ -61,6 +67,13 @@ def test_recoverable_flag(app, client, get_message):
     response = client.get('/reset/' + token)
     assert b'<h1>Reset password</h1>' in response.data
 
+    # Test submitting a new password but leave out confirm
+    response = client.post('/reset/' + token, data={
+        'password': 'newpassword',
+    }, follow_redirects=True)
+    assert get_message('PASSWORD_NOT_PROVIDED') in response.data
+    assert len(recorded_resets) == 0
+
     # Test submitting a new password
     response = client.post('/reset/' + token, data={
         'password': 'newpassword',
@@ -79,15 +92,6 @@ def test_recoverable_flag(app, client, get_message):
         'newpassword',
         follow_redirects=True)
     assert b'Hello joe@lp.com' in response.data
-
-    logout(client)
-
-    # Test submitting JSON
-    response = client.post('/reset', data='{"email": "joe@lp.com"}', headers={
-        'Content-Type': 'application/json'
-    })
-    assert response.headers['Content-Type'] == 'application/json'
-    assert 'user' not in response.jdata['response']
 
     logout(client)
 
@@ -120,6 +124,92 @@ def test_recoverable_flag(app, client, get_message):
     assert get_message('INVALID_RESET_PASSWORD_TOKEN') in response.data
 
 
+@pytest.mark.settings()
+def test_recoverable_json(app, client, get_message):
+    recorded_resets = []
+    recorded_instructions_sent = []
+
+    @password_reset.connect_via(app)
+    def on_password_reset(app, user):
+        recorded_resets.append(user)
+
+    @reset_password_instructions_sent.connect_via(app)
+    def on_instructions_sent(app, user, token):
+        recorded_instructions_sent.append(user)
+
+    with capture_flashes() as flashes:
+        # Test reset password creates a token and sends email
+        with capture_reset_password_requests() as requests:
+            with app.mail.record_messages() as outbox:
+                response = client.post('/reset',
+                                       data='{"email": "joe@lp.com"}',
+                                       headers={'Content-Type':
+                                                'application/json'})
+                assert response.headers['Content-Type'] == 'application/json'
+
+        assert len(recorded_instructions_sent) == 1
+        assert len(outbox) == 1
+        assert response.status_code == 200
+        token = requests[0]['token']
+
+        # Test invalid email
+        response = client.post('/reset',
+                               data='{"email": "whoknows@lp.com"}',
+                               headers={'Content-Type': 'application/json'})
+        assert response.status_code == 400
+        assert response.jdata['response']['errors']['email'][0] \
+            .encode('utf-8') == \
+            get_message('USER_DOES_NOT_EXIST')
+
+        # Test submitting a new password but leave out 'confirm'
+        response = client.post('/reset/' + token,
+                               data='{"password": "newpassword"}',
+                               headers={'Content-Type': 'application/json'})
+        assert response.status_code == 400
+        assert response.jdata['response']['errors']['password_confirm'][0] \
+            .encode('utf-8') == \
+            get_message('PASSWORD_NOT_PROVIDED')
+
+        # Test submitting a new password
+        response = client.post('/reset/' + token,
+                               data='{"password": "newpassword",\
+                                     "password_confirm": "newpassword"}',
+                               headers={'Content-Type': 'application/json'})
+        assert all(k in response.jdata['response']['user']
+                   for k in ['id', 'authentication_token'])
+        assert len(recorded_resets) == 1
+
+        # reset automatically logs user in
+        logout(client)
+
+        # Test logging in with the new password
+        response = client.post('/login',
+                               data='{"email": "joe@lp.com",\
+                                     "password": "newpassword"}',
+                               headers={'Content-Type': 'application/json'})
+        assert all(k in response.jdata['response']['user']
+                   for k in ['id', 'authentication_token'])
+
+        logout(client)
+
+        # Use token again - should fail since already have set new password.
+        response = client.post('/reset/' + token,
+                               data='{"password": "newpassword",\
+                                     "password_confirm": "newpassword"}',
+                               headers={'Content-Type': 'application/json'})
+        assert response.status_code == 400
+        assert len(recorded_resets) == 1
+
+        # Test invalid token
+        response = client.post('/reset/bogus',
+                               data='{"password": "newpassword",\
+                                     "password_confirm": "newpassword"}',
+                               headers={'Content-Type': 'application/json'})
+        assert response.jdata['response']['errors'].encode('utf-8') == \
+            get_message('INVALID_RESET_PASSWORD_TOKEN')
+    assert len(flashes) == 0
+
+
 def test_login_form_description(sqlalchemy_app):
     app = sqlalchemy_app()
     with app.test_request_context('/login'):
@@ -142,16 +232,48 @@ def test_expired_reset_token(client, get_message):
 
     time.sleep(1)
 
+    with capture_flashes() as flashes:
+        msg = get_message(
+            'PASSWORD_RESET_EXPIRED',
+            within='1 milliseconds',
+            email=user.email)
+
+        # Test getting reset form with expired token
+        response = client.get('/reset/' + token, follow_redirects=True)
+        assert msg in response.data
+
+        # Test trying to reset password with expired token
+        response = client.post('/reset/' + token, data={
+            'password': 'newpassword',
+            'password_confirm': 'newpassword'
+        }, follow_redirects=True)
+
+        assert msg in response.data
+    assert len(flashes) == 2
+
+
+def test_bad_reset_token(client, get_message):
+    # Test invalid token - get form
+    response = client.get('/reset/bogus', follow_redirects=True)
+    assert get_message('INVALID_RESET_PASSWORD_TOKEN') in response.data
+
+    # Test invalid token - reset password
+    response = client.post('/reset/bogus', data={
+        'password': 'newpassword',
+        'password_confirm': 'newpassword'
+    }, follow_redirects=True)
+    assert get_message('INVALID_RESET_PASSWORD_TOKEN') in response.data
+
+    # Test mangled token
+    token = (
+        "WyIxNjQ2MzYiLCIxMzQ1YzBlZmVhM2VhZjYwODgwMDhhZGU2YzU0MzZjMiJd."
+        "BZEw_Q.lQyo3npdPZtcJ_sNHVHP103syjM"
+        "&url_id=fbb89a8328e58c181ea7d064c2987874bc54a23d")
     response = client.post('/reset/' + token, data={
         'password': 'newpassword',
         'password_confirm': 'newpassword'
     }, follow_redirects=True)
-
-    msg = get_message(
-        'PASSWORD_RESET_EXPIRED',
-        within='1 milliseconds',
-        email=user.email)
-    assert msg in response.data
+    assert get_message('INVALID_RESET_PASSWORD_TOKEN') in response.data
 
 
 def test_reset_token_deleted_user(app, client, get_message,
@@ -252,3 +374,80 @@ def test_custom_reset_templates(client):
 
     response = client.get('/reset/' + token)
     assert b'CUSTOM RESET PASSWORD' in response.data
+
+
+@pytest.mark.settings(
+    redirect_host='localhost:8081',
+    redirect_behavior='spa',
+    reset_view='/reset-redirect')
+def test_spa_get(app, client):
+    """
+    Test 'single-page-application' style redirects
+    This uses json only.
+    """
+    with capture_reset_password_requests() as requests:
+        response = client.post('/reset', data='{"email": "joe@lp.com"}',
+                               headers={'Content-Type': 'application/json'})
+        assert response.headers['Content-Type'] == 'application/json'
+        assert 'user' not in response.jdata['response']
+    token = requests[0]['token']
+
+    response = client.get('/reset/' + token)
+    assert response.status_code == 302
+    split = urlsplit(response.headers['Location'])
+    assert 'localhost:8081' == split.netloc
+    assert '/reset-redirect' == split.path
+    qparams = dict(parse_qsl(split.query))
+    assert qparams['email'] == 'joe@lp.com'
+    assert qparams['token'] == token
+
+
+@pytest.mark.settings(
+    reset_password_within='1 milliseconds',
+    redirect_host='localhost:8081',
+    redirect_behavior='spa',
+    reset_error_view='/reset-error')
+def test_spa_get_bad_token(app, client, get_message):
+    """ Test expired and invalid token"""
+    with capture_flashes() as flashes:
+        with capture_reset_password_requests() as requests:
+            response = client.post('/reset', data='{"email": "joe@lp.com"}',
+                                   headers={'Content-Type':
+                                            'application/json'})
+            assert response.headers['Content-Type'] == 'application/json'
+            assert 'user' not in response.jdata['response']
+        token = requests[0]['token']
+        time.sleep(1)
+
+        response = client.get('/reset/' + token)
+        assert response.status_code == 302
+        split = urlsplit(response.headers['Location'])
+        assert 'localhost:8081' == split.netloc
+        assert '/reset-error' == split.path
+        qparams = dict(parse_qsl(split.query))
+        assert len(qparams) == 2
+        assert all(k in qparams for k in ['email', 'error'])
+
+        msg = get_message(
+            'PASSWORD_RESET_EXPIRED',
+            within='1 milliseconds',
+            email='joe@lp.com')
+        assert msg == qparams['error'].encode('utf-8')
+
+        # Test mangled token
+        token = (
+            "WyIxNjQ2MzYiLCIxMzQ1YzBlZmVhM2VhZjYwODgwMDhhZGU2YzU0MzZjMiJd."
+            "BZEw_Q.lQyo3npdPZtcJ_sNHVHP103syjM"
+            "&url_id=fbb89a8328e58c181ea7d064c2987874bc54a23d")
+        response = client.get('/reset/' + token)
+        assert response.status_code == 302
+        split = urlsplit(response.headers['Location'])
+        assert 'localhost:8081' == split.netloc
+        assert '/reset-error' == split.path
+        qparams = dict(parse_qsl(split.query))
+        assert len(qparams) == 1
+        assert all(k in qparams for k in ['error'])
+
+        msg = get_message('INVALID_RESET_PASSWORD_TOKEN')
+        assert msg == qparams['error'].encode('utf-8')
+    assert len(flashes) == 0


### PR DESCRIPTION
Reset Password, passwordless login, and confirmation did not support SPA/json since
those three had confirmation links that only returned redirects or forms. SPAs need to get control
of all redirects and have the appropriate context. Three new 'views' are available:
RESET_VIEW, RESET_ERROR_VIEW, and LOGIN_ERROR_VIEW to enable easy routing within the UI.

This change introduces a new config variable - SECURITY_REDIRECT_BEHAVIOR which will change those redirects to SPA-friendly
redirects. A new overridable UserMixin method - get_redirect_qparams allows for customizing precisely what
query arguments are sent via the redirect.
By default of course the existing form-based redirects are done.

A new configuration variable - REDIRECT_HOST can be used during development to force redirects to a different netloc
useful when the UI is running separately (e.g. via npm).

Continued to improve the openapi.yaml file to document these changes

Improved unit tests by:
1) verifying 'flashes' - for json/SPA - we don't want any.
2) improve performance by not using bcrypt for login tokens during testing.