### PR TITLE
Fix doc on new token cache configuration variables.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -80,16 +80,16 @@ Core
 ``SECURITY_DEFAULT_HTTP_AUTH_REALM``     Specifies the default authentication
                                          realm when using basic HTTP auth.
                                          Defaults to ``Login Required``
-``USE_VERIFY_PASSWORD_CACHE``            If ``True`` Enables cache for token
+``SECURITY_USE_VERIFY_PASSWORD_CACHE``   If ``True`` Enables cache for token
                                          verification, make it quicker further
                                          calls to authenticated routes using
                                          token and slow hash algorithms
                                          (like bcrypt). Defaults to ``None``
-``VERIFY_HASH_CACHE_MAX_SIZE``           Limitation for token validation cache size
+``SECURITY_VERIFY_HASH_CACHE_MAX_SIZE``  Limitation for token validation cache size
                                          Rules are the ones of TTLCache of
                                          cachetools package. Defaults to
                                          ``500``
-``VERIFY_HASH_CACHE_TTL``                Time to live for password check cache entries.
+``SECURITY_VERIFY_HASH_CACHE_TTL``       Time to live for password check cache entries.
                                          Defaults to ``300`` (5 minutes)
 ``SECURITY_REDIRECT_BEHAVIOR``           Passwordless login, confirmation, and
                                          reset password have GET endpoints that validate


### PR DESCRIPTION
They were missing the 'SECURITY_' prefix.