### PR TITLE
fix: Improve 2FA views.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -118,77 +118,86 @@ URLs and Views
 
 .. tabularcolumns:: |p{6.5cm}|p{8.5cm}|
 
-=============================== ================================================
-``SECURITY_LOGIN_URL``          Specifies the login URL. Defaults to ``/login``.
-``SECURITY_LOGOUT_URL``         Specifies the logout URL. Defaults to
-                                ``/logout``.
-``SECURITY_REGISTER_URL``       Specifies the register URL. Defaults to
-                                ``/register``.
-``SECURITY_RESET_URL``          Specifies the password reset URL. Defaults to
-                                ``/reset``.
-``SECURITY_CHANGE_URL``         Specifies the password change URL. Defaults to
-                                ``/change``.
-``SECURITY_CONFIRM_URL``        Specifies the email confirmation URL. Defaults
-                                to ``/confirm``.
-``SECURITY_POST_LOGIN_VIEW``    Specifies the default view to redirect to after
-                                a user logs in. This value can be set to a URL
-                                or an endpoint name. Defaults to ``/``.
-``SECURITY_POST_LOGOUT_VIEW``   Specifies the default view to redirect to after
-                                a user logs out. This value can be set to a URL
-                                or an endpoint name. Defaults to ``/``.
-``SECURITY_CONFIRM_ERROR_VIEW`` Specifies the view to redirect to if a
-                                confirmation error occurs. This value can be set
-                                to a URL or an endpoint name. If this value is
-                                ``None``, the user is presented the default view
-                                to resend a confirmation link.
-                                In the case of ``SECURITY_REDIRECT_BEHAVIOR`` == ``spa``
-                                query params in the redirect will contain the error.
-                                Defaults to``None``.
-``SECURITY_POST_REGISTER_VIEW`` Specifies the view to redirect to after a user
-                                successfully registers. This value can be set to
-                                a URL or an endpoint name. If this value is
-                                ``None``, the user is redirected to the value of
-                                ``SECURITY_POST_LOGIN_VIEW``. Defaults to
-                                ``None``.
-``SECURITY_POST_CONFIRM_VIEW``  Specifies the view to redirect to after a user
-                                successfully confirms their email. This value
-                                can be set to a URL or an endpoint name. If this
-                                value is ``None``, the user is redirected  to the
-                                value of ``SECURITY_POST_LOGIN_VIEW``. Defaults
-                                to ``None``.
-``SECURITY_POST_RESET_VIEW``    Specifies the view to redirect to after a user
-                                successfully resets their password. This value
-                                can be set to a URL or an endpoint name. If this
-                                value is ``None``, the user is redirected  to the
-                                value of ``SECURITY_POST_LOGIN_VIEW``. Defaults
-                                to ``None``.
-``SECURITY_POST_CHANGE_VIEW``   Specifies the view to redirect to after a user
-                                successfully changes their password. This value
-                                can be set to a URL or an endpoint name. If this
-                                value is ``None``, the user is redirected  to the
-                                value of ``SECURITY_POST_LOGIN_VIEW``. Defaults
-                                to ``None``.
-``SECURITY_UNAUTHORIZED_VIEW``  Specifies the view to redirect to if a user
-                                attempts to access a URL/endpoint that they do
-                                not have permission to access. If this value is
-                                ``None``, the user is presented with a default
-                                HTTP 403 response. Defaults to ``None``.
-``SECURITY_RESET_VIEW``         Specifies the view/URL to redirect to after a GET
-                                reset-password link. This is only valid if
-                                ``SECURITY_REDIRECT_BEHAVIOR`` == ``spa``. Query params
-                                in the redirect will contain the token and email.
-                                Defaults to ``None``
-``SECURITY_RESET_ERROR_VIEW``   Specifies the view/URL to redirect to after a GET
-                                reset-password link when there is an error. This is only valid if
-                                ``SECURITY_REDIRECT_BEHAVIOR`` == ``spa``. Query params
-                                in the redirect will contain the error.
-                                Defaults to ``None``
-``SECURITY_LOGIN_ERROR_VIEW``   Specifies the view/URL to redirect to after a GET
-                                passwordless link when there is an error. This is only valid if
-                                ``SECURITY_REDIRECT_BEHAVIOR`` == ``spa``. Query params
-                                in the redirect will contain the error.
-                                Defaults to ``None``
-=============================== ================================================
+============================================ ================================================
+``SECURITY_LOGIN_URL``                       Specifies the login URL. Defaults to ``/login``.
+``SECURITY_LOGOUT_URL``                      Specifies the logout URL. Defaults to
+                                             ``/logout``.
+``SECURITY_REGISTER_URL``                    Specifies the register URL. Defaults to
+                                             ``/register``.
+``SECURITY_RESET_URL``                       Specifies the password reset URL. Defaults to
+                                             ``/reset``.
+``SECURITY_CHANGE_URL``                      Specifies the password change URL. Defaults to
+                                             ``/change``.
+``SECURITY_CONFIRM_URL``                     Specifies the email confirmation URL. Defaults
+                                             to ``/confirm``.
+``SECURITY_TWO_FACTOR_SETUP_URL``            Specifies the two factor setup URL. Defaults to ``/tf-setup``.
+``SECURITY_TWO_FACTOR_TOKEN_VALIDATION_URL`` Specifies the two factor token validation URL.
+                                             Defaults to ``/tf-validate``.
+``SECURITY_TWO_FACTOR_QRCODE_URL``           Specifies the two factor request QrCode URL.
+                                             Defaults to ``/tf-qrcode``.
+``SECURITY_TWO_FACTOR_RESCUE_URL``           Specifies the two factor rescue URL.
+                                             Defaults to ``/tf-rescue``.
+``SECURITY_TWO_FACTOR_CONFIRM_URL``          Specifies the two factor password confirmation URL.
+                                             Defaults to ``/tf-confirm``.
+``SECURITY_POST_LOGIN_VIEW``                 Specifies the default view to redirect to after
+                                             a user logs in. This value can be set to a URL
+                                             or an endpoint name. Defaults to ``/``.
+``SECURITY_POST_LOGOUT_VIEW``                Specifies the default view to redirect to after
+                                             a user logs out. This value can be set to a URL
+                                             or an endpoint name. Defaults to ``/``.
+``SECURITY_CONFIRM_ERROR_VIEW``              Specifies the view to redirect to if a
+                                             confirmation error occurs. This value can be set
+                                             to a URL or an endpoint name. If this value is
+                                             ``None``, the user is presented the default view
+                                             to resend a confirmation link.
+                                             In the case of ``SECURITY_REDIRECT_BEHAVIOR`` == ``spa``
+                                             query params in the redirect will contain the error.
+                                             Defaults to``None``.
+``SECURITY_POST_REGISTER_VIEW``              Specifies the view to redirect to after a user
+                                             successfully registers. This value can be set to
+                                             a URL or an endpoint name. If this value is
+                                             ``None``, the user is redirected to the value of
+                                             ``SECURITY_POST_LOGIN_VIEW``. Defaults to
+                                             ``None``.
+``SECURITY_POST_CONFIRM_VIEW``               Specifies the view to redirect to after a user
+                                             successfully confirms their email. This value
+                                             can be set to a URL or an endpoint name. If this
+                                             value is ``None``, the user is redirected  to the
+                                             value of ``SECURITY_POST_LOGIN_VIEW``. Defaults
+                                             to ``None``.
+``SECURITY_POST_RESET_VIEW``                 Specifies the view to redirect to after a user
+                                             successfully resets their password. This value
+                                             can be set to a URL or an endpoint name. If this
+                                             value is ``None``, the user is redirected  to the
+                                             value of ``SECURITY_POST_LOGIN_VIEW``. Defaults
+                                             to ``None``.
+``SECURITY_POST_CHANGE_VIEW``                Specifies the view to redirect to after a user
+                                             successfully changes their password. This value
+                                             can be set to a URL or an endpoint name. If this
+                                             value is ``None``, the user is redirected  to the
+                                             value of ``SECURITY_POST_LOGIN_VIEW``. Defaults
+                                             to ``None``.
+``SECURITY_UNAUTHORIZED_VIEW``               Specifies the view to redirect to if a user
+                                             attempts to access a URL/endpoint that they do
+                                             not have permission to access. If this value is
+                                             ``None``, the user is presented with a default
+                                             HTTP 403 response. Defaults to ``None``.
+``SECURITY_RESET_VIEW``                      Specifies the view/URL to redirect to after a GET
+                                             reset-password link. This is only valid if
+                                             ``SECURITY_REDIRECT_BEHAVIOR`` == ``spa``. Query params
+                                             in the redirect will contain the token and email.
+                                             Defaults to ``None``
+``SECURITY_RESET_ERROR_VIEW``                Specifies the view/URL to redirect to after a GET
+                                             reset-password link when there is an error. This is only valid if
+                                             ``SECURITY_REDIRECT_BEHAVIOR`` == ``spa``. Query params
+                                             in the redirect will contain the error.
+                                             Defaults to ``None``
+``SECURITY_LOGIN_ERROR_VIEW``                Specifies the view/URL to redirect to after a GET
+                                             passwordless link when there is an error. This is only valid if
+                                             ``SECURITY_REDIRECT_BEHAVIOR`` == ``spa``. Query params
+                                             in the redirect will contain the error.
+                                             Defaults to ``None``
+============================================ ================================================
 
 
 Template Paths

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -74,6 +74,11 @@ _default_config = {
     'RESET_URL': '/reset',
     'CHANGE_URL': '/change',
     'CONFIRM_URL': '/confirm',
+    'TWO_FACTOR_SETUP_URL': '/tf-setup',
+    'TWO_FACTOR_TOKEN_VALIDATION_URL': '/tf-validate',
+    'TWO_FACTOR_QRCODE_URL': '/tf-qrcode',
+    'TWO_FACTOR_RESCUE_URL': '/tf-rescue',
+    'TWO_FACTOR_CONFIRM_URL': '/tf-confirm',
     'POST_LOGIN_VIEW': '/',
     'POST_LOGOUT_VIEW': '/',
     'CONFIRM_ERROR_VIEW': None,
@@ -553,6 +558,15 @@ class _SecurityState(object):
 
     def mail_context_processor(self, fn):
         self._add_ctx_processor('mail', fn)
+
+    def two_factor_change_method_password_confirmation_context_processor(self, fn):
+        self._add_ctx_processor('two_factor_change_method_password_confirmation', fn)
+
+    def two_factor_setup_context_processor(self, fn):
+        self._add_ctx_processor('two_factor_setup', fn)
+
+    def two_factor_token_validation_context_processor(self, fn):
+        self._add_ctx_processor('two_factor_token_validation', fn)
 
     def send_mail_task(self, fn):
         self._send_mail_task = fn

--- a/tests/templates/custom_security/tf_choose.html
+++ b/tests/templates/custom_security/tf_choose.html
@@ -1,0 +1,3 @@
+CUSTOM TWO FACTOR SETUP
+{{ global }}
+{{ foo }}

--- a/tests/templates/custom_security/tf_verify.html
+++ b/tests/templates/custom_security/tf_verify.html
@@ -1,0 +1,3 @@
+CUSTOM TWO FACTOR VERIFY CODE
+{{ global }}
+{{ foo }}

--- a/tests/templates/custom_security/tfc.html
+++ b/tests/templates/custom_security/tfc.html
@@ -1,0 +1,3 @@
+CUSTOM TWO FACTOR CHANGE
+{{ global }}
+{{ foo }}


### PR DESCRIPTION
as documented in Issue #90:

- add initialization and tests for the 3 2FA form context processors.
- for 2fa login - improve JSON response so can decide what next state is.
- add 2FA URL configurations and documentation.
- allow for both 2FA and normal logins - see below.

All logins now go through /login - however if SECURITY_TWO_FACTOR is true - all login's
require 2FA. Next step is to make this per-user. No change in behavior.

Backwards compat:
Other 2FA views have changed default endpoint URLS:

/two_factor_setup_function -> /tf-setup
/two_factor_token_validation -> tf-validate
/change/two_factor_password_confirmation -> /tf-confirm
/two_factor_rescue_function -> /tf-rescue

closes: #90