### PR TITLE
feature: Improve 2FA

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -146,14 +146,25 @@ sends the following signals.
    Sent when a user requests a password reset. In addition to the app (which is
    the sender), it is passed `user` and `token` arguments.
 
-.. data:: user_two_factored
+.. data:: tf_code_confirmed
 
     Sent when a user performs two-factor authentication login on the site. In
-    addition to the app (which is the sender), it is passed `user` argument
+    addition to the app (which is the sender), it is passed `user`
+    and `method` arguments.
 
-.. data:: two_factor_method_changed
+.. data:: tf_profile_changed
 
   Sent when two-factor is used and user logs in. In addition to the app
+  (which is the sender), it is passed `user` and `method` arguments.
+
+.. data:: tf_disabled
+
+  Sent when two-factor is disabled. In addition to the app
   (which is the sender), it is passed `user` argument.
+
+.. data:: tf_security_token_sent
+
+  Sent when a two factor security/access code is sent. In addition to the app
+  (which is the sender), it is passed `user`, `method`, and `token` arguments.
 
 .. _Flask documentation on signals: http://flask.pocoo.org/docs/signals/

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -286,11 +286,9 @@ Feature Flags
 ``SECURITY_TWO_FACTOR``   Specifies if Flask-Security should enable the
                           two-factor login feature. If set to ``True``, in
                           addition to their passwords, users will be required to
-                          enter a code that is sent to them. The added feature
-                          includes the ability to send it either via email, sms
-                          message, or Google Authenticator. Default time of
-                          validity is 30 seconds in Google Authenticator and up
-                          to 60 seconds if sent by mail or sms.
+                          enter a code that is sent to them. Note that unless
+                          ``SECURITY_TWO_FACTOR_REQUIRED`` is set - this is
+                          opt-in.
                           Defaults to ``False``.
 ========================= ======================================================
 
@@ -374,28 +372,12 @@ Miscellaneous
                                               enabled. Always pluralized the
                                               time unit for this value.
                                               Defaults to ``1 days``.
-``SECURITY_TWO_FACTOR_GOOGLE_AUTH_VALIDITY``  Specifies the number of time
-                                              windows user has before the token
-                                              generated for him using google
-                                              authenticator is valid. time
-                                              windows specifies the amount of
-                                              time, which is 30 seconds for each
-                                              window. Default to 0, which is up
-                                              to 30 seconds.
-``SECURITY_TWO_FACTOR_MAIL_VALIDITY``         Specifies the number of time
-                                              windows user has before the token
-                                              sent to him using mail is valid.
-                                              time windows specifies the amount
-                                              of time, which is 30 seconds for
-                                              each window. Default to 1, which
-                                              is up to 60 seconds.
-``SECURITY_TWO_FACTOR_SMS_VALIDITY``          Specifies the number of time
-                                              windows user has before the token
-                                              sent to him using sms is valid.
-                                              time windows specifies the amount
-                                              of time, which is 30 seconds for
-                                              each window. Default to 5, which
-                                              is up to 3 minutes.                                                                                            .
+``SECURITY_TWO_FACTOR_GOOGLE_AUTH_VALIDITY``  Specifies the number of seconds access token is
+                                              valid. Defaults to 2 minutes.
+``SECURITY_TWO_FACTOR_MAIL_VALIDITY``         Specifies the number of seconds
+                                              access token is valid. Defaults to 5 minutes.
+``SECURITY_TWO_FACTOR_SMS_VALIDITY``          Specifies the number of seconds access token is
+                                              valid. Defaults to 2 minutes.
 ``SECURITY_LOGIN_WITHOUT_CONFIRMATION``       Specifies if a user may login
                                               before confirming their email when
                                               the value of
@@ -421,6 +403,9 @@ Miscellaneous
 ``SECURITY_DEFAULT_REMEMBER_ME``              Specifies the default "remember
                                               me" value used when logging in
                                               a user. Defaults to ``False``.
+``SECURITY_TWO_FACTOR_REQUIRED``              If set to ``True`` then all users will be
+                                              required to setup and use two factor authorization.
+                                              Defaults to ``False``.
 ``SECURITY_TWO_FACTOR_ENABLED_METHODS``       Specifies the default enabled
                                               methods for two-factor
                                               authentication. Defaults to
@@ -490,5 +475,6 @@ The default messages and error levels can be found in ``core.py``.
 * ``SECURITY_MSG_TWO_FACTOR_PASSWORD_CONFIRMATION_NEEDED``
 * ``SECURITY_MSG_TWO_FACTOR_PERMISSION_DENIED``
 * ``SECURITY_MSG_TWO_FACTOR_METHOD_NOT_AVAILABLE``
+* ``SECURITY_MSG_TWO_FACTOR_DISABLED``
 * ``SECURITY_MSG_UNAUTHORIZED``
 * ``SECURITY_MSG_USER_DOES_NOT_EXIST``

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -64,8 +64,9 @@ The following is a list of all the available context processor decorators:
 * ``change_password_context_processor``: Change password view
 * ``send_confirmation_context_processor``: Send confirmation view
 * ``send_login_context_processor``: Send login view
-* ``two_factor_setup_context_processor``: Two factor setup view
-* ``two_factor_token_validation_context_processor``: Two factor token validation view
+* ``tf_setup_context_processor``: Two factor setup view
+* ``tf_token_validation_context_processor``: Two factor token validation view
+* ``tf_password_verify``: Two factor password re-verify view
 
 
 Forms

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -66,11 +66,11 @@ Two-factor Authentication (experimental)
 Two-factor authentication is enabled by generating time-based one time passwords
 (Tokens). The tokens are generated using the users totp secret, which is unique
 per user, and is generated both on first login, and when changing the two-factor
-method. (Doing this causes the previous totp secret to become invalid) The token
+method (Doing this causes the previous totp secret to become invalid). The token
 is provided by one of 3 methods - email, sms (service is not provided), or
 Google Authenticator. By default, tokens provided by google authenticator are
-valid for 30 seconds, tokens sent by mail for up to 1 minute and tokens sent by
-sms for up to 3 minutes. The QR code used to supply Google Authenticator with
+valid for 2 minutes, tokens sent by mail for up to 5 minute and tokens sent by
+sms for up to 2 minutes. The QR code used to supply Google Authenticator with
 the secret is generated using the PyQRCode library.
 This feature is marked experimental meaning that backwards incompatible changes
 might occur during minor releases. While the feature is operational, it has these
@@ -79,7 +79,6 @@ known limitations:
     * Limited and incomplete JSON support
     * Incomplete i18n support
     * Not enough documentation to use w/o looking at code
-    * While confirming 2FA - encrypted TOTP is sent in cookie
 
 Email Confirmation
 ------------------

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -8,6 +8,7 @@
     :copyright: (c) 2012 by Matt Wright.
     :copyright: (c) 2017 by CERN.
     :copyright: (c) 2017 by ETH Zurich, Swiss Data Science Center.
+    :copyright: (c) 2019 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 
@@ -130,9 +131,9 @@ _default_config = {
     "SEND_PASSWORD_RESET_EMAIL": True,
     "SEND_PASSWORD_RESET_NOTICE_EMAIL": True,
     "LOGIN_WITHIN": "1 days",
-    "TWO_FACTOR_GOOGLE_AUTH_VALIDITY": 0,
-    "TWO_FACTOR_MAIL_VALIDITY": 1,
-    "TWO_FACTOR_SMS_VALIDITY": 5,
+    "TWO_FACTOR_GOOGLE_AUTH_VALIDITY": 120,
+    "TWO_FACTOR_MAIL_VALIDITY": 300,
+    "TWO_FACTOR_SMS_VALIDITY": 120,
     "CONFIRM_EMAIL_WITHIN": "5 days",
     "RESET_PASSWORD_WITHIN": "5 days",
     "LOGIN_WITHOUT_CONFIRMATION": False,
@@ -178,6 +179,7 @@ _default_config = {
     "USE_VERIFY_PASSWORD_CACHE": False,
     "VERIFY_HASH_CACHE_TTL": 60 * 5,
     "VERIFY_HASH_CACHE_MAX_SIZE": 500,
+    "TWO_FACTOR_REQUIRED": False,
     "TWO_FACTOR_SECRET": None,
     "TWO_FACTOR_ENABLED_METHODS": ["mail", "google_authenticator", "sms"],
     "TWO_FACTOR_URI_SERVICE_NAME": "service_name",
@@ -286,6 +288,10 @@ _default_messages = {
         "error",
     ),
     "TWO_FACTOR_METHOD_NOT_AVAILABLE": (_("Marked method is not valid"), "error"),
+    "TWO_FACTOR_DISABLED": (
+        _("You successfully disabled two factor authorization."),
+        "success",
+    ),
 }
 
 _default_forms = {
@@ -566,14 +572,14 @@ class _SecurityState(object):
     def mail_context_processor(self, fn):
         self._add_ctx_processor("mail", fn)
 
-    def two_factor_change_method_password_confirmation_context_processor(self, fn):
-        self._add_ctx_processor("two_factor_change_method_password_confirmation", fn)
+    def tf_password_verify_context_processor(self, fn):
+        self._add_ctx_processor("tf_password_verify", fn)
 
-    def two_factor_setup_context_processor(self, fn):
-        self._add_ctx_processor("two_factor_setup", fn)
+    def tf_setup_context_processor(self, fn):
+        self._add_ctx_processor("tf_setup", fn)
 
-    def two_factor_token_validation_context_processor(self, fn):
-        self._add_ctx_processor("two_factor_token_validation", fn)
+    def tf_token_validation_context_processor(self, fn):
+        self._add_ctx_processor("tf_token_validation", fn)
 
     def send_mail_task(self, fn):
         self._send_mail_task = fn

--- a/flask_security/signals.py
+++ b/flask_security/signals.py
@@ -17,8 +17,6 @@ user_registered = signals.signal("user-registered")
 
 user_confirmed = signals.signal("user-confirmed")
 
-user_two_factored = signals.signal("user-two-factored")
-
 confirm_instructions_sent = signals.signal("confirm-instructions-sent")
 
 login_instructions_sent = signals.signal("login-instructions-sent")
@@ -27,6 +25,12 @@ password_reset = signals.signal("password-reset")
 
 password_changed = signals.signal("password-changed")
 
-two_factor_method_changed = signals.signal("two-factor-method-changed")
-
 reset_password_instructions_sent = signals.signal("password-reset-instructions-sent")
+
+tf_code_confirmed = signals.signal("tf-code-confirmed")
+
+tf_profile_changed = signals.signal("tf-profile-changed")
+
+tf_security_token_sent = signals.signal("tf-security-token-sent")
+
+tf_disabled = signals.signal("tf-disabled")

--- a/flask_security/translations/flask_security.pot
+++ b/flask_security/translations/flask_security.pot
@@ -343,3 +343,7 @@ msgstr ""
 #: flask_security/core.py:259
 msgid "Marked method is not valid"
 msgstr ""
+
+#: flask_security/core.py
+msgid "You successfully disabled two factor authorization."
+msgstr ""

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 addopts = -xrs --cov flask_security --cov-report term-missing --black --flake8 --cache-clear
 flake8-max-line-length = 88
+flake8-ignore =
+    tests/view_scaffold.py E402

--- a/tests/test_context_processors.py
+++ b/tests/test_context_processors.py
@@ -105,6 +105,7 @@ def test_passwordless_login_context_processor(app, client):
 
 @pytest.mark.two_factor()
 @pytest.mark.settings(
+    two_factor_required=True,
     login_user_template="custom_security/login_user.html",
     two_factor_change_method_password_confirmation_template="custom_security/tfc.html",
     two_factor_choose_method_template="custom_security/tf_choose.html",
@@ -116,7 +117,7 @@ def test_two_factor_context_processors(client, app):
     def default_ctx_processor():
         return {"global": "global"}
 
-    @app.security.two_factor_change_method_password_confirmation_context_processor
+    @app.security.tf_password_verify_context_processor
     def send_two_factor_confirm():
         return {"foo": "bar"}
 
@@ -126,7 +127,7 @@ def test_two_factor_context_processors(client, app):
     assert b"bar" in response.data
     logout(client)
 
-    @app.security.two_factor_setup_context_processor
+    @app.security.tf_setup_context_processor
     def send_two_factor_setup():
         return {"foo": "bar"}
 
@@ -137,7 +138,7 @@ def test_two_factor_context_processors(client, app):
     assert b"bar" in response.data
     logout(client)
 
-    @app.security.two_factor_token_validation_context_processor
+    @app.security.tf_token_validation_context_processor
     def send_two_factor_token_validation():
         return {"foo": "bar"}
 

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -1,0 +1,189 @@
+# :copyright: (c) 2019 by J. Christopher Wagner (jwag).
+# :license: MIT, see LICENSE for more details.
+
+"""
+This is simple scaffold that can be run as an app and manually test
+various views using a browser.
+
+Configurations can be set via environment variables.
+
+Runs on port 5001
+
+In order to start - you need to register a user.
+To confirm - take the token printed on the console - and put that in your browser
+at /confirm/{token}
+
+
+Since we don't actually send email - we have signal handlers dump the required
+data to the console.
+
+"""
+import os
+
+from flask import Flask, render_template_string
+from flask_babelex import Babel
+from flask_mail import Mail
+from flask.json import JSONEncoder
+from flask_security import (
+    Security,
+    current_user,
+    login_required,
+    SQLAlchemySessionUserDatastore,
+)
+from flask_security.signals import (
+    tf_security_token_sent,
+    reset_password_instructions_sent,
+    user_registered,
+)
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config["DEBUG"] = True
+    app.config["SECRET_KEY"] = "super-secret"
+    app.config["LOGIN_DISABLED"] = False
+    app.config["WTF_CSRF_ENABLED"] = False
+    # Don't actually send any email - instead we subscribe to signals
+    # and print out required info.
+    app.config["MAIL_SUPPRESS_SEND"] = True
+    app.config["SECURITY_TWO_FACTOR_SECRET"] = {
+        "1": "TjQ9Qa31VOrfEzuPy4VHQWPCTmRzCnFzMKLxXYiZu9B"
+    }
+
+    app.config["SECURITY_PASSWORD_SALT"] = "salty"
+    # Make this plaintext for most tests - reduces unit test time by 50%
+    app.config["SECURITY_PASSWORD_HASH"] = "plaintext"
+    # Make this hex_md5 for token tests
+    app.config["SECURITY_HASHING_SCHEMES"] = ["hex_md5"]
+    app.config["SECURITY_DEPRECATED_HASHING_SCHEMES"] = []
+
+    for opt in [
+        "changeable",
+        "recoverable",
+        "registerable",
+        "trackable",
+        "NOTpasswordless",
+        "confirmable",
+        "two_factor",
+    ]:
+        app.config["SECURITY_" + opt.upper()] = True
+
+    if os.environ.get("SETTINGS"):
+        app.config.from_envvar("SETTINGS")
+    mail = Mail(app)
+    babel = Babel(app)
+    app.babel = babel
+    app.json_encoder = JSONEncoder
+    app.mail = mail
+    # Setup Flask-Security
+    user_datastore = SQLAlchemySessionUserDatastore(db_session, User, Role)
+    Security(app, user_datastore)
+
+    # Create a user to test with
+    @app.before_first_request
+    def create_user():
+        init_db()
+        db_session.commit()
+
+    @user_registered.connect_via(app)
+    def on_user_registerd(myapp, user, confirm_token):
+        print("User {} registered with token {}".format(user.email, confirm_token))
+
+    @reset_password_instructions_sent.connect_via(app)
+    def on_reset(myapp, user, token):
+        print("User {} started password reset with token {}".format(user.email, token))
+
+    @tf_security_token_sent.connect_via(app)
+    def on_token_sent(myapp, user, token, method):
+        print(
+            "User {} was sent two factor token {} via {}".format(
+                user.email, token, method
+            )
+        )
+
+    # Views
+    @app.route("/")
+    @login_required
+    def home():
+        return render_template_string("Hello {{email}} !", email=current_user.email)
+
+    return app
+
+
+"""
+
+Datastore
+
+"""
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy.ext.declarative import declarative_base
+
+engine = create_engine(
+    "sqlite:////tmp/view_scaffold.db?check_same_thread=False", convert_unicode=True
+)
+db_session = scoped_session(
+    sessionmaker(autocommit=False, autoflush=False, bind=engine)
+)
+Base = declarative_base()
+Base.query = db_session.query_property()
+
+
+def init_db():
+    # import all modules here that might define models so that
+    # they will be registered properly on the metadata.  Otherwise
+    # you will have to import them first before calling init_db()
+    Base.metadata.create_all(bind=engine)
+
+
+"""
+
+Required Models
+
+"""
+
+from flask_security import UserMixin, RoleMixin
+from sqlalchemy.orm import relationship, backref
+from sqlalchemy import Boolean, DateTime, Column, Integer, String, ForeignKey
+
+
+class RolesUsers(Base):
+    __tablename__ = "roles_users"
+    id = Column(Integer(), primary_key=True)
+    user_id = Column("user_id", Integer(), ForeignKey("user.id"))
+    role_id = Column("role_id", Integer(), ForeignKey("role.id"))
+
+
+class Role(Base, RoleMixin):
+    __tablename__ = "role"
+    id = Column(Integer(), primary_key=True)
+    name = Column(String(80), unique=True)
+    description = Column(String(255))
+
+
+class User(Base, UserMixin):
+    __tablename__ = "user"
+    id = Column(Integer, primary_key=True)
+    email = Column(String(255), unique=True)
+    username = Column(String(255))
+    password = Column(String(255))
+    last_login_at = Column(DateTime())
+    current_login_at = Column(DateTime())
+    last_login_ip = Column(String(100))
+    current_login_ip = Column(String(100))
+    login_count = Column(Integer)
+    active = Column(Boolean())
+    confirmed_at = Column(DateTime())
+
+    phone_number = Column(String(64))
+    two_factor_primary_method = Column(String(140))
+    totp_secret = Column(String(255))
+
+    roles = relationship(
+        "Role", secondary="roles_users", backref=backref("users", lazy="dynamic")
+    )
+
+
+if __name__ == "__main__":
+    create_app().run(port=5001)


### PR DESCRIPTION
A rather large refactor with 2 main goals:

1) remove sending personal info as part of initialization during signup
2) implement opt-in in addition to 2FA required mode.

While the basic flow and forms didn't change - there were many changes:

- A new configuration variable SECURITY_TWO_FACTOR_REQUIRED (default False)
  If you want old behavior of requiring 2FA - this must be set.
- Contents of session cookie are completely different.
- CHANGED: Signal names:
   - 'user-two-factored' -> 'tf_code_confirmed'
   - 'two_factor_method_changed' -> 'tf_profile_changed'
- 2 New signals introduced: 'tf_disabled' and 'tf_security_token_sent'
- Code for most 2FA views changed dramatically, however the actual flow
  should be compatible.
- CHANGE: if call /tf-setup and haven't re-confirmed password - now redirect to
  two_factor_confirm_url rather than login_url.
- CHANGED: as part of naming rationalization - the context processor names changed:
   - two_factor_change_method_password_confirmation_context_processor -> tf_password_verify_context_processor
   - two_factor_setup_context_processor -> tf_setup_context_processor
   - two_factor_token_validation_context_processor -> tf_token_validation_context_processor

Various bugs and doc improvements:

- The two factor _VALIDITY configuration variables were fixed to reflect prior changes
  which meant these values are now in seconds.
- A new message TWO_FACTOR_DISABLED was introduced

Testing Improvements:

- view_scaffold.py was introduced that makes it easy to test forms. This is a real
  Flask application that can be run, and using a normal browser can interact with
  various workflows.

Closes #95 