### PR TITLE
Fix form label translations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ install:
   - "pip install -e .[all]"
 
 script:
+  - python setup.py compile_catalog
   - python setup.py test
   - >
     set -e;

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -663,6 +663,8 @@ class Security(object):
 
         @app.before_first_request
         def _register_i18n():
+            # N.B. as of jinja 2.9 '_' is always registered
+            # http://jinja.pocoo.org/docs/2.10/extensions/#i18n-extension
             if "_" not in app.jinja_env.globals:
                 app.jinja_env.globals["_"] = state.i18n_domain.gettext
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,8 +101,7 @@ def app(request):
 
     mail = Mail(app)
     if babel is None or babel.args[0]:
-        babel = Babel(app)
-        app.babel = babel
+        Babel(app)
     app.json_encoder = JSONEncoder
     app.mail = mail
 

--- a/tests/templates/_nav.html
+++ b/tests/templates/_nav.html
@@ -1,5 +1,5 @@
 {%- if current_user.is_authenticated -%}
-  <p>Hello {{ current_user.email }}</p>
+  <p>{{ _('Welcome') }} {{ current_user.email }}</p>
 {%- endif %}
 <ul>
   <li><a href="{{ url_for('index') }}">Index</a></li>

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -27,7 +27,7 @@ def test_authenticate(client):
     response = authenticate(client)
     assert response.status_code == 302
     response = authenticate(client, follow_redirects=True)
-    assert b"Hello matt@lp.com" in response.data
+    assert b"Welcome matt@lp.com" in response.data
 
 
 def test_authenticate_with_next(client):
@@ -50,7 +50,7 @@ def test_authenticate_with_invalid_malformed_next(client, get_message):
 
 def test_authenticate_case_insensitive_email(app, client):
     response = authenticate(client, "MATT@lp.com", follow_redirects=True)
-    assert b"Hello matt@lp.com" in response.data
+    assert b"Welcome matt@lp.com" in response.data
 
 
 def test_authenticate_with_invalid_input(client, get_message):

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -192,7 +192,7 @@ def test_confirmation_different_user_when_logged_in(client, get_message):
 
     response = client.get("/confirm/" + token2, follow_redirects=True)
     assert get_message("EMAIL_CONFIRMED") in response.data
-    assert b"Hello lady@lp.com" in response.data
+    assert b"Welcome lady@lp.com" in response.data
 
 
 @pytest.mark.registerable()

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -86,7 +86,7 @@ def test_recoverable_flag(app, client, get_message):
 
     # Test logging in with the new password
     response = authenticate(client, "joe@lp.com", "newpassword", follow_redirects=True)
-    assert b"Hello joe@lp.com" in response.data
+    assert b"Welcome joe@lp.com" in response.data
 
     logout(client)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -63,6 +63,14 @@ def get_session(response):
                 return val[1]
 
 
+def check_xlation(app, locale):
+    """ Return True if locale is loaded """
+    with app.test_request_context():
+        domain = app.security.i18n_domain
+        xlations = domain.get_translations()
+        return xlations and xlations._info.get("language", None) == locale
+
+
 def create_roles(ds):
     for role in ("admin", "editor", "author"):
         ds.create_role(name=role)


### PR DESCRIPTION
Basic problem was that the label was being translated at declaration time - which is outside
of any request or even security/app context.
Instead, create a lazy_string which is then evaluated in the correct context.

Added tests for this.
There are other odd aspects of translating form contents itself that will need some more
work - but add a test at least so we can track it.

@rhaamo

closes #108