### PR TITLE
Fix for form validation error message translations.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,9 +18,10 @@ Released TBD
 - (:pr:`79` Add POST logout to enhance JSON usage (jwag956).
 - (:pr:`73`) Fix get_user for various DBs (jwag956).
   This is a more complete fix than in opr #633.
-- (:pr:`78`) Add formal openapi API spec (jwag956).
+- (:pr:`78`, :pr:`103`) Add formal openapi API spec (jwag956).
 - (:pr:`86`, :pr:`94`, :pr:`98`, :pr:`101`, :pr:`104`) Add Two-factor authentication (opr #842) (baurt, jwag956).
 - (:issue:`108`) Fix form field label translations (jwag956)
+- (:issue:`115`) Fix form error message translations (upstream #801) (jwag956)
 - (:issue:`87`) Convert entire repo to Black (baurt)
 
 Version 3.1.0

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ tests_require = [
     "coverage>=4.0",
     "cryptography>=2.3.0",
     "isort>=4.2.2",
-    "mirakuru==1.1.0",
     "mock>=1.3.0",
     "mongoengine>=0.12.0",
     "mongomock>=3.14.0",


### PR DESCRIPTION
validation messages must be lazy_strings so that they are evaluated per-request.

Improve view_scaffold to be i18n aware.
Improve view_scaffold to create a test user on startup.

removed mirakuru version pin since they fixed issue.

closes: #115 