### PR TITLE
Feature - implement granular Permissions.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,22 @@ Flask-Security Changelog
 
 Here you can see the full list of changes between each Flask-Security release.
 
+Version 3.3.0
+-------------
+
+Released TBD
+
+- (:pr:`120`) Native support for Permissions as part of Roles. Endpoints can be
+  protected via permissions that are evaluated based on role(s) that the user has.
+
+Possible compatibility issues:
+
+- (:pr:`120` RoleMixin now has a method ``get_permissions`` which is called as part
+  each request to add Permissions to the authenticated user. It checks if the RoleModel
+  has a property ``permissions`` and assumes it is a comma separated string of permissions.
+  If your model already has such a property this will likely fail. You need to override ``get_permissions``
+  and simply return an emtpy set. (jwag956)
+
 Version 3.2.0
 -------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,6 +15,7 @@ recursive-include docs *.py
 recursive-include docs *.rst
 recursive-include docs *.txt
 recursive-include docs Makefile
+recursive-include examples *.py
 recursive-include flask_security/templates *.*
 recursive-include flask_security/translations *.po *.pot *.mo
 recursive-include tests *.py

--- a/README.rst
+++ b/README.rst
@@ -36,9 +36,12 @@ Goals
 * Regain momentum for this critical piece of the Flask eco-system. To that end the
   the plan is to put out small, frequent releases starting with pulling the simplest
   and most obvious changes that have already been vetted in the upstream version, as
-  well as other pull requests.
+  well as other pull requests. This was completed with the June 29 2019 3.2.0 release.
 * Continue work to get Flask-Security to be usable from Single Page Applications,
-  such as those built with Vue and Angular, that have no html forms
+  such as those built with Vue and Angular, that have no html forms.
+* Migrate to more modern paradigms such as using oauth2 and JWT for token acquisition.
+* Be more opinionated and 'batteries' included by reducing reliance on abandoned projects and
+  bundling in support for common use cases.
 * Any other great ideas.
 
 Contributing

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -24,6 +24,10 @@ Protecting Views
 
 .. autofunction:: flask_security.decorators.roles_accepted
 
+.. autofunction:: flask_security.decorators.permissions_required
+
+.. autofunction:: flask_security.decorators.permissions_accepted
+
 .. autofunction:: flask_security.decorators.http_auth_required
 
 .. autofunction:: flask_security.decorators.auth_token_required
@@ -55,6 +59,10 @@ Datastores
     :members:
 
 .. autoclass:: flask_security.datastore.SQLAlchemyUserDatastore
+    :members:
+    :inherited-members:
+
+.. autoclass:: flask_security.datastore.SQLAlchemySessionUserDatastore
     :members:
     :inherited-members:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"Flask-Security"
-copyright = u"2012-2019, Matt Wright"
+copyright = u"2012-2019"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -273,8 +273,8 @@ texinfo_documents = [
 # Bibliographic Dublin Core info.
 epub_title = u"Flask-Security"
 epub_author = u"Matt Wright"
-epub_publisher = u"Matt Wright"
-epub_copyright = u"2012, Matt Wright"
+epub_publisher = u"J. Christopher Wagner"
+epub_copyright = u"2012-2019"
 
 # The language of the text. It defaults to the language option
 # or en if the language is not set.

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -21,10 +21,16 @@ Role/Identity Based Access
 Flask-Security implements very basic role management out of the box. This means
 that you can associate a high level role or multiple roles to any user. For
 instance, you may assign roles such as `Admin`, `Editor`, `SuperUser`, or a
-combination of said roles to a user. Access control is based on the role name
+combination of said roles to a user. Access control is based on the role name and/or
+permissions contained within the role;
 and all roles should be uniquely named. This feature is implemented using the
-`Flask-Principal`_ extension. If you'd like to implement more granular access
-control, you can refer to the Flask-Principal `documentation on this topic`_.
+`Flask-Principal`_ extension. As with basic RBAC, permissions can be assigned to roles
+to provide more granular access control. Permissions can be associated with one or
+more roles (the RoleModel contains a list of permissions). The values of
+permissions are completely up to the developer - Flask-Security simply treats them
+as strings.
+If you'd like to implement even more granular access
+control (such as per-object), you can refer to the Flask-Principal `documentation on this topic`_.
 
 
 Password Hashing

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ Flask-Security allows you to quickly add common security mechanisms to your
 Flask application. They include:
 
 1. Session based authentication
-2. Role management
+2. Role and Permission management
 3. Password hashing
 4. Basic HTTP authentication
 5. Token based authentication

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -5,7 +5,17 @@ Flask-Security assumes you'll be using libraries such as SQLAlchemy,
 MongoEngine, Peewee or PonyORM to define a data model that includes a `User`
 and `Role` model. The fields on your models must follow a particular convention
 depending on the functionality your app requires. Aside from this, you're free
-to add any additional fields to your model(s) if you want. At the bare minimum
+to add any additional fields to your model(s) if you want.
+
+As more features are added to Flask-Security, the requirements for required fields and tables grow.
+As you use these features, and therefore use these fields and tables, database migrations are required;
+which are a bit of a pain. To make things easier - Flask-Security includes mixins that
+contain ALL the fields and tables required for all features. They also contain
+various `best practice` fields - such as update and create times. These mixins can
+be easily extended to add any sort of custom fields and can be found in the
+`models` module (today there is just one for using Flask-SqlAlchemy).
+
+At the bare minimum
 your `User` and `Role` model should include the following fields:
 
 **User**
@@ -65,6 +75,13 @@ If you include 'sms' in `SECURITY_TWO_FACTOR_ENABLED_METHODS`, your `User` model
 will require the following additional field:
 
 * ``tf_phone_number``
+
+Permissions
+^^^^^^^^^^^
+If you want to protect endpoints with permissions, and assign permissions to roles
+that are then assigned to users the Role model requires:
+
+* ``permissions``
 
 Custom User Payload
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,6 +1,9 @@
 Quick Start
 ===========
 
+There are some complete (but simple) examples available in the *examples* directory of the
+`Flask-Security repo`_
+
 * :ref:`basic-sqlalchemy-application`
 * :ref:`basic-sqlalchemy-application-with-session`
 * :ref:`basic-mongoengine-application`
@@ -26,14 +29,14 @@ SQLAlchemy Application
 ~~~~~~~~~~~~~~~~~~~~~~
 
 The following code sample illustrates how to get started as quickly as
-possible using SQLAlchemy:
+possible using Flask-SQLAlchemy and the built-in model mixins:
 
 ::
 
-    from flask import Flask, render_template
+    from flask import Flask, render_template_string
     from flask_sqlalchemy import SQLAlchemy
-    from flask_security import Security, SQLAlchemyUserDatastore, \
-        UserMixin, RoleMixin, login_required
+    from flask_security import Security, SQLAlchemyUserDatastore, login_required
+    from flask_security.models import fsqla
 
     # Create app
     app = Flask(__name__)
@@ -47,23 +50,13 @@ possible using SQLAlchemy:
     db = SQLAlchemy(app)
 
     # Define models
-    roles_users = db.Table('roles_users',
-            db.Column('user_id', db.Integer(), db.ForeignKey('user.id')),
-            db.Column('role_id', db.Integer(), db.ForeignKey('role.id')))
+    fsqla.FsModels.set_db_info(db)
 
-    class Role(db.Model, RoleMixin):
-        id = db.Column(db.Integer(), primary_key=True)
-        name = db.Column(db.String(80), unique=True)
-        description = db.Column(db.String(255))
+    class Role(db.Model, fsqla.FsRoleMixin):
+        pass
 
-    class User(db.Model, UserMixin):
-        id = db.Column(db.Integer, primary_key=True)
-        email = db.Column(db.String(255), unique=True)
-        password = db.Column(db.String(255))
-        active = db.Column(db.Boolean())
-        confirmed_at = db.Column(db.DateTime())
-        roles = db.relationship('Role', secondary=roles_users,
-                                backref=db.backref('users', lazy='dynamic'))
+    class User(db.Model, fsqla.FsUserMixin):
+        pass
 
     # Setup Flask-Security
     user_datastore = SQLAlchemyUserDatastore(db, User, Role)
@@ -73,14 +66,14 @@ possible using SQLAlchemy:
     @app.before_first_request
     def create_user():
         db.create_all()
-        user_datastore.create_user(email='matt@nobien.net', password='password')
+        user_datastore.create_user(email='test@me.com', password='password')
         db.session.commit()
 
     # Views
     @app.route('/')
     @login_required
     def home():
-        return render_template('index.html')
+        return render_template_string("Hello {{ current_user.email }}")
 
     if __name__ == '__main__':
         app.run()
@@ -99,14 +92,14 @@ SQLAlchemy Install requirements
      $ pip install flask-security-too sqlalchemy
 
 Also, you can use the extension `Flask-SQLAlchemy-Session documentation
-<http://flask-sqlalchemy-session.readthedocs.io/en/v1.1/>`_.
+<http://flask-sqlalchemy-session.readthedocs.io/en/latest/>`_.
 
 SQLAlchemy Application
 ~~~~~~~~~~~~~~~~~~~~~~
 
 The following code sample illustrates how to get started as quickly as
 possible using `SQLAlchemy in a declarative way
-<http://flask.pocoo.org/docs/0.12/patterns/sqlalchemy/#declarative>`_:
+<http://flask.pocoo.org/docs/1.0/patterns/sqlalchemy/#declarative>`_:
 
 We are gonna split the application at least in three files: app.py, database.py
 and models.py. You can also do the models a folder and spread your tables there.
@@ -403,3 +396,5 @@ with a single HTTP proxy in front of the web application::
 
 To learn more about the ``ProxyFix`` middleware, please see the
 `Werkzeug documentation <http://werkzeug.pocoo.org/docs/latest/contrib/fixers/#werkzeug.contrib.fixers.ProxyFix>`_.
+
+.. _Flask-Security repo: https://github.com/jwag956/flask-security

--- a/docs/two_factor_configurations.rst
+++ b/docs/two_factor_configurations.rst
@@ -12,8 +12,8 @@ possible using SQLAlchemy and two-factor feature:
 
 -  `Basic SQLAlchemy Application <#basic-sqlalchemy-application>`_
 
-Basic SQLAlchemy Application
-=============================
+Basic SQLAlchemy Two-Factor Application
+========================================
 
 SQLAlchemy Install requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+# Copyright 2019 by J. Christopher Wagner (jwag). All rights reserved.

--- a/examples/fsqlalchemy1.py
+++ b/examples/fsqlalchemy1.py
@@ -1,0 +1,132 @@
+"""
+Copyright 2019 by J. Christopher Wagner (jwag). All rights reserved.
+:license: MIT, see LICENSE for more details.
+
+Very simple application.
+Uses built-in models.
+Shows using roles and permissions to protect endpoints.
+"""
+
+from flask import Flask, abort, render_template_string
+from flask.json import JSONEncoder
+from flask_sqlalchemy import SQLAlchemy
+from flask_security import (
+    Security,
+    SQLAlchemyUserDatastore,
+    current_user,
+    login_required,
+    permissions_accepted,
+    permissions_required,
+    roles_accepted,
+)
+from flask_security.models import fsqla
+
+# Create app
+app = Flask(__name__)
+app.config["DEBUG"] = True
+app.config["SECRET_KEY"] = "super-secret"
+app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+# Bcrypt is set as default SECURITY_PASSWORD_HASH, which requires a salt
+app.config["SECURITY_PASSWORD_SALT"] = "super-secret-random-salt"
+
+app.json_encoder = JSONEncoder
+
+# Create database connection object
+db = SQLAlchemy(app)
+
+# Define models
+fsqla.FsModels.set_db_info(db)
+
+
+class Role(db.Model, fsqla.FsRoleMixin):
+    pass
+
+
+class User(db.Model, fsqla.FsUserMixin):
+    blogs = db.relationship("Blog", backref="user", lazy="dynamic")
+    pass
+
+
+class Blog(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    text = db.Column(db.UnicodeText)
+
+
+# Setup Flask-Security
+user_datastore = SQLAlchemyUserDatastore(db, User, Role)
+security = Security(app, user_datastore)
+
+
+# Create users and roles (and first blog!)
+@app.before_first_request
+def create_users():
+    db.create_all()
+    user_datastore.create_role(
+        name="admin",
+        permissions={"admin-read", "admin-write", "user-read", "user-write"},
+    )
+    user_datastore.create_role(name="monitor", permissions={"admin-read", "user-read"})
+    user_datastore.create_role(name="user", permissions={"user-read", "user-write"})
+    user_datastore.create_role(name="reader", permissions={"user-read"})
+
+    user_datastore.create_user(
+        email="admin@me.com", password="password", roles=["admin"]
+    )
+    user_datastore.create_user(
+        email="ops@me.com", password="password", roles=["monitor"]
+    )
+    real_user = user_datastore.create_user(
+        email="user@me.com", password="password", roles=["user"]
+    )
+    user_datastore.create_user(
+        email="reader@me.com", password="password", roles=["reader"]
+    )
+
+    # create initial blog
+    blog = Blog(text="my first blog", user=real_user)
+    db.session.add(blog)
+    db.session.commit()
+    print("First blog id {}".format(blog.id))
+
+
+# Views
+# Note that we always add @login_required so that if a client isn't logged in
+# we will get a proper '401' and redirected to login page.
+@app.route("/")
+@login_required
+def home():
+    return render_template_string("Hello {{ current_user.email }}")
+
+
+@app.route("/admin")
+@login_required
+@permissions_accepted("admin-read", "admin-write")
+def admin():
+    return render_template_string("Hello on admin page")
+
+
+@app.route("/ops")
+@login_required
+@roles_accepted("monitor")
+def monitor():
+    # Example of using just a role. Note that 'admin' can't access this
+    # since it doesn't have the 'monitor' role - even though it has
+    # all the permissions that the 'monitor' role has.
+    return render_template_string("Hello OPS")
+
+
+@app.route("/blog/<bid>", methods=["GET", "POST"])
+@login_required
+@permissions_required("user-write")
+def update_blog(bid):
+    # Yes caller has write permission - but do they OWN this blog?
+    blog = Blog.query.get(bid)
+    if current_user != blog.user:
+        abort(403)
+    return render_template_string("Yes, {{ current_user.email }} can update blog")
+
+
+if __name__ == "__main__":
+    app.run(port=5001)

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -25,6 +25,8 @@ from .decorators import (
     roles_accepted,
     roles_required,
     auth_required,
+    permissions_accepted,
+    permissions_required,
 )
 from .forms import (
     ForgotPasswordForm,
@@ -69,6 +71,8 @@ __all__ = (
     "login_user",
     "logout_user",
     "password_reset",
+    "permissions_required",
+    "permissions_accepted",
     "reset_password_instructions_sent",
     "roles_accepted",
     "roles_required",

--- a/flask_security/cli.py
+++ b/flask_security/cli.py
@@ -6,6 +6,7 @@
     Command Line Interface for managing accounts and roles.
 
     :copyright: (c) 2016 by CERN.
+    :copyright: (c) 2019 by J. Christopher Wagner
     :license: MIT, see LICENSE for more details.
 """
 
@@ -77,10 +78,17 @@ def users_create(identity, password, active):
 @roles.command("create")
 @click.argument("name")
 @click.option("-d", "--description", default=None)
+@click.option("-p", "--permissions")
 @with_appcontext
 @commit
 def roles_create(**kwargs):
     """Create a role."""
+
+    # For some reaosn Click puts arguments in kwargs - even if they weren't specified.
+    if "permissions" in kwargs and not kwargs["permissions"]:
+        del kwargs["permissions"]
+    if "permissions" in kwargs and not hasattr(_datastore.role_model, "permissions"):
+        raise click.UsageError("Role model does not support permissions")
     _datastore.create_role(**kwargs)
     click.secho('Role "%(name)s" created successfully.' % kwargs, fg="green")
 

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -212,7 +212,24 @@ class UserDatastore(object):
         return False
 
     def create_role(self, **kwargs):
-        """Creates and returns a new role from the given parameters."""
+        """
+        Creates and returns a new role from the given parameters.
+        Supported params (depending on RoleModel):
+
+        :param name: Role name
+        :param permissions: a comma delimited list of permissions, a set or a list.
+            These are user-defined
+            strings that correspond to strings used with @permissions_required()
+
+        """
+
+        # By default we just use raw DB model create - for permissions we want to
+        # be nicer and allow sending in a list or set or comma separated string.
+        if "permissions" in kwargs and hasattr(self.role_model, "permissions"):
+            perms = kwargs["permissions"]
+            if isinstance(perms, list) or isinstance(perms, set):
+                perms = ",".join(perms)
+            kwargs["permissions"] = perms
 
         role = self.role_model(**kwargs)
         return self.put(role)

--- a/flask_security/models/__init__.py
+++ b/flask_security/models/__init__.py
@@ -1,0 +1,12 @@
+""""
+Copyright 2019 by J. Christopher Wagner (jwag). All rights reserved.
+:license: MIT, see LICENSE for more details.
+
+This packages contains OPTIONAL models for various ORMs/databases that can be used
+to quickly get the required DB models setup.
+
+These models have the fields for ALL features. This makes it easy for applications
+to add features w/o a DB migration (and modern DBs are pretty efficient at storing
+empty values!).
+
+"""

--- a/flask_security/models/fsqla.py
+++ b/flask_security/models/fsqla.py
@@ -1,0 +1,153 @@
+"""
+Copyright 2019 by J. Christopher Wagner (jwag). All rights reserved.
+:license: MIT, see LICENSE for more details.
+
+
+Complete models for all features when using Flask-SqlAlchemy
+"""
+
+import datetime
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Column,
+    Integer,
+    String,
+    UnicodeText,
+    ForeignKey,
+)
+from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from flask_security import RoleMixin, UserMixin
+
+
+class FsModels(object):
+    """
+    Helper class for model mixins.
+    This records the ``db`` (which is a Flask-SqlAlchemy object) for use in
+    mixins.
+    """
+
+    roles_to_users = None
+    db = None
+
+    @classmethod
+    def set_db_info(cls, appdb):
+        cls.db = appdb
+        cls.roles_to_users = appdb.Table(
+            "roles_to_users",
+            Column("user_id", Integer(), ForeignKey("user.id")),
+            Column("role_id", Integer(), ForeignKey("role.id")),
+        )
+
+
+class FsRoleMixin(RoleMixin):
+    id = Column(Integer(), primary_key=True)
+    name = Column(String(80), unique=True, nullable=False)
+    description = Column(String(255))
+    # A comma separated list of strings
+    permissions = Column(UnicodeText, nullable=True)
+    update_datetime = Column(
+        DateTime,
+        nullable=False,
+        server_default=func.now(),
+        onupdate=datetime.datetime.utcnow,
+    )
+
+
+class FsUserMixin(UserMixin):
+    """ User information
+    """
+
+    # flask_security basic fields
+    id = Column(Integer, primary_key=True)
+    email = Column(String(255), unique=True)
+    # Username is important since shouldn't expose email to other users in most cases.
+    username = Column(String(255))
+    password = Column(String(255))
+    active = Column(Boolean())
+
+    # confirmable
+    confirmed_at = Column(DateTime())
+
+    # trackable
+    last_login_at = Column(DateTime())
+    current_login_at = Column(DateTime())
+    last_login_ip = Column(String(64))
+    current_login_ip = Column(String(64))
+    login_count = Column(Integer)
+
+    # 2FA
+    tf_primary_method = Column(String(64), nullable=True)
+    tf_totp_secret = Column(String(255), nullable=True)
+    tf_phone_number = Column(String(128), nullable=True)
+
+    @declared_attr
+    def roles(cls):
+        return FsModels.db.relationship(
+            "Role",
+            secondary=FsModels.roles_to_users,
+            backref=FsModels.db.backref("users", lazy="dynamic"),
+        )
+
+    create_datetime = Column(DateTime, nullable=False, server_default=func.now())
+    update_datetime = Column(
+        DateTime,
+        nullable=False,
+        server_default=func.now(),
+        onupdate=datetime.datetime.utcnow,
+    )
+
+
+"""
+These are placeholders - not current used
+"""
+
+
+class FsOauth2ClientMixin(object):
+    """ Oauth2 client """
+
+    id = Column(String(64), primary_key=True)
+
+    @declared_attr
+    def user_id(cls):
+        return Column(
+            Integer, ForeignKey("user.id", ondelete="CASCADE"), nullable=False
+        )
+
+    @declared_attr
+    def user(cls):
+        return relationship("User")
+
+    grant_type = Column(String(32), nullable=False)
+    scopes = Column(UnicodeText(), default="")
+    response_type = Column(UnicodeText, nullable=False, default="")
+    redirect_uris = Column(UnicodeText())
+
+
+class FsTokenMixin(object):
+    """ (Bearer) Tokens that have been given out """
+
+    id = Column(Integer, primary_key=True)
+
+    @declared_attr
+    def client_id(cls):
+        return Column(
+            Integer, ForeignKey("oauth2_client.id", ondelete="CASCADE"), nullable=False
+        )
+
+    # client = relationship("fs_oauth2_client")
+    @declared_attr
+    def user_id(cls):
+        return Column(
+            Integer, ForeignKey("user.id", ondelete="CASCADE"), nullable=False
+        )
+
+    scopes = Column(UnicodeText(), default="")
+    revoked = Column(Boolean(), nullable=False, default=False)
+    access_token = Column(String(100), unique=True, nullable=False)
+    refresh_token = Column(String(100), unique=True)
+    issued_at = Column(DateTime, nullable=False, server_default=func.now())
+    expires_at = Column(DateTime())

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -6,10 +6,12 @@
     Flask-Security utils module
 
     :copyright: (c) 2012-2019 by Matt Wright.
+    :copyright: (c) 2019 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 import abc
 import base64
+from functools import partial
 import hashlib
 import hmac
 import sys
@@ -22,7 +24,7 @@ from flask.signals import message_flashed
 from flask_login import login_user as _login_user
 from flask_login import logout_user as _logout_user
 from flask_mail import Message
-from flask_principal import AnonymousIdentity, Identity, identity_changed
+from flask_principal import AnonymousIdentity, Identity, identity_changed, Need
 from itsdangerous import BadSignature, SignatureExpired
 from werkzeug.local import LocalProxy
 
@@ -58,6 +60,9 @@ if PY3:  # pragma: no cover
 else:  # pragma: no cover
     string_types = (basestring,)  # noqa
     text_type = unicode  # noqa
+
+FsPermNeed = partial(Need, "fsperm")
+FsPermNeed.__doc__ = """A need with the method preset to `"fsperm"`."""
 
 
 def _(translate):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,6 +54,21 @@ def test_cli_createrole(script_info):
     assert result.exit_code == 0
 
 
+def test_cli_createrole_with_perms(script_info):
+    """Test create user CLI."""
+    runner = CliRunner()
+
+    # Create role
+    result = runner.invoke(
+        roles_create,
+        ["superusers", "-d", "Test description", "-p", "super, full-write"],
+        obj=script_info,
+    )
+
+    # Some datastores don't support permissions.
+    assert result.exit_code == 0 or result.exit_code == 2
+
+
 def test_cli_addremove_role(script_info):
     """Test add/remove role."""
     runner = CliRunner()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -170,6 +170,32 @@ def test_roles_accepted(client):
 
 
 @pytest.mark.settings(unauthorized_view="/")
+def test_permissions_accepted(client):
+    for user in ("matt@lp.com", "joe@lp.com"):
+        authenticate(client, user)
+        response = client.get("/admin_perm")
+        assert b"Admin Page with full-write or super" in response.data
+        logout(client)
+
+    authenticate(client, "jill@lp.com")
+    response = client.get("/admin_perm", follow_redirects=True)
+    assert b"Home Page" in response.data
+
+
+@pytest.mark.settings(unauthorized_view="/")
+def test_permissions_required(client):
+    for user in ["matt@lp.com"]:
+        authenticate(client, user)
+        response = client.get("/admin_perm_required")
+        assert b"Admin Page required" in response.data
+        logout(client)
+
+    authenticate(client, "joe@lp.com")
+    response = client.get("/admin_perm_required", follow_redirects=True)
+    assert b"Home Page" in response.data
+
+
+@pytest.mark.settings(unauthorized_view="/")
 def test_unauthenticated_role_required(client, get_message):
     response = client.get("/admin", follow_redirects=True)
     assert get_message("UNAUTHORIZED") in response.data

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -72,8 +72,17 @@ def check_xlation(app, locale):
 
 
 def create_roles(ds):
-    for role in ("admin", "editor", "author"):
-        ds.create_role(name=role)
+    roles = [
+        ("admin", ["full-read", "full-write", "super"]),
+        ("editor", ["full-read", "full-write"]),
+        ("author", ["full-read", "my-write"]),
+        ("simple", []),
+    ]
+    for role in roles:
+        if hasattr(ds.role_model, "permissions"):
+            ds.create_role(name=role[0], permissions=",".join(role[1]))
+        else:
+            ds.create_role(name=role[0])
     ds.commit()
 
 


### PR DESCRIPTION
Added support for permissions within a role (standard RBAC).

The RoleMixin provide methods for getting and modifying permissions (which
are stored as a simple comma separated string).

2 new decorators - permissions_required and permissions_accepted can be used to protect
endpoints.

Permissions are simple strings and not interpreted by Flask-Security at all.

As support for this and additional functionality -introduced the idea of entire model mixins
that set up complete User and Role models for all functionality (and for future new tables).
These models also include some best practice constructs such as update_datetime and username.
These are NOT required, but are an attempt to reduce effort to integrate Flask-Security.