### PR TITLE
Fix - improve documentation and other small bug fixes.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,10 +10,18 @@ Released TBD
 
 - (:pr:`120`) Native support for Permissions as part of Roles. Endpoints can be
   protected via permissions that are evaluated based on role(s) that the user has.
+- Improve documentation for :meth:`.UserDatastore.create_user` to make clear that hashed password
+  should be passed in.
+- Improve documentation for :class:`.UserDatastore` and :func:`.verify_and_update_password`
+  to make clear that caller must commit changers to DB if using a session based datastore.
+- (:issue:`122`) Clarify when to use ``confirm_register_form`` rather than ``register_form``.
+- Fix bug in 2FA that didn't commit DB after using `verify_and_update_password`.
+- Fix bug(s) in UserDatastore where changes to user ``active`` flag weren't being
+  added to DB.
 
 Possible compatibility issues:
 
-- (:pr:`120` RoleMixin now has a method ``get_permissions`` which is called as part
+- (:pr:`120`) :class:`.RoleMixin` now has a method :meth:`.get_permissions` which is called as part
   each request to add Permissions to the authenticated user. It checks if the RoleModel
   has a property ``permissions`` and assumes it is a comma separated string of permissions.
   If your model already has such a property this will likely fail. You need to override ``get_permissions``

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -312,8 +312,8 @@ epub_copyright = u"2012-2019"
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"http://docs.python.org/": None}
+intersphinx_mapping = {"https://docs.python.org/3": None}
 
-# -- Options for spinx-issues ---------------------------------------------
+# -- Options for sphinx-issues ---------------------------------------------
 # Github repo
 issues_github_path = "jwag956/flask-security"

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -171,8 +171,8 @@ _default_config = {
     "EMAIL_SUBJECT_PASSWORD_RESET": _("Password reset instructions"),
     "EMAIL_PLAINTEXT": True,
     "EMAIL_HTML": True,
-    "EMAIL_SUBJECT_TWO_FACTOR": "Two-factor Login",
-    "EMAIL_SUBJECT_TWO_FACTOR_RESCUE": "Two-factor Rescue",
+    "EMAIL_SUBJECT_TWO_FACTOR": _("Two-factor Login"),
+    "EMAIL_SUBJECT_TWO_FACTOR_RESCUE": _("Two-factor Rescue"),
     "USER_IDENTITY_ATTRIBUTES": ["email"],
     "HASHING_SCHEMES": ["sha256_crypt", "hex_md5"],
     "DEPRECATED_HASHING_SCHEMES": ["hex_md5"],
@@ -589,7 +589,20 @@ class UserMixin(BaseUserMixin):
         return existing
 
     def verify_and_update_password(self, password):
-        """Verify and update user password using configured hash."""
+        """Returns ``True`` if the password is valid for the specified user.
+
+        Additionally, the hashed password in the database is updated if the
+        hashing algorithm happens to have changed.
+
+        N.B. you MUST call DB commit if you are using a session-based datastore
+        (such as SqlAlchemy) since the user instance might have been altered
+        (i.e. ``app.security.datastore.commit()``).
+        This is usually handled in the view.
+
+        .. versionadded:: 3.2.0
+
+        :param password: A plaintext password to verify
+        """
         return verify_and_update_password(password, self)
 
 
@@ -673,13 +686,19 @@ class Security(object):
     :param datastore: An instance of a user datastore.
     :param register_blueprint: to register the Security blueprint or not.
     :param login_form: set form for the login view
-    :param register_form: set form for the register view
-    :param confirm_register_form: set form for the confirm register view
+    :param register_form: set form for the register view when
+            SECURITY_CONFIRMABLE is false
+    :param confirm_register_form: set form for the register view when
+            SECURITY_CONFIRMABLE is true
     :param forgot_password_form: set form for the forgot password view
     :param reset_password_form: set form for the reset password view
     :param change_password_form: set form for the change password view
     :param send_confirmation_form: set form for the send confirmation view
     :param passwordless_login_form: set form for the passwordless login view
+    :param two_factor_setup_form: set form for the 2FA setup view
+    :param two_factor_verify_code_form: set form the the 2FA verify code view
+    :param two_factor_rescue_form: set form for the 2FA rescue view
+    :param two_factor_verify_password_form: set form for the 2FA verify password view
     :param anonymous_user: class to use for anonymous user
     :param render_template: function to use to render templates
     :param send_mail: function to use to send email

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -109,9 +109,12 @@ def login_user(user, remember=None):
 
 
 def logout_user():
-    """Logs out the current.
+    """Logs out the current user.
 
     This will also clean up the remember me cookie if it exists.
+
+    This sends an ``identity_changed`` signal to note that the current
+    identity is now the `AnonymousIdentity`
     """
 
     for key in ("identity.name", "identity.auth_type"):
@@ -159,6 +162,11 @@ def verify_and_update_password(password, user):
 
     Additionally, the hashed password in the database is updated if the
     hashing algorithm happens to have changed.
+
+    N.B. you MUST call DB commit if you are using a session-based datastore
+    (such as SqlAlchemy) since the user instance might have been altered
+    (i.e. ``app.security.datastore.commit()``).
+    This is usually handled in the view.
 
     :param password: A plaintext password to verify
     :param user: The user to verify against

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -838,6 +838,8 @@ def two_factor_verify_password():
         form = form_class()
 
     if form.validate_on_submit():
+        # form called verify_and_update_password()
+        after_this_request(_commit)
         session["tf_confirmed"] = True
         if not request.is_json:
             do_flash(*get_message("TWO_FACTOR_PASSWORD_CONFIRMATION_DONE"))

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -22,6 +22,14 @@ class Role(RoleMixin):
     pass
 
 
+class MockDatastore(UserDatastore):
+    def put(self, model):
+        pass
+
+    def delete(self, model):
+        pass
+
+
 def test_unimplemented_datastore_methods():
     datastore = Datastore(None)
     assert datastore.db is None
@@ -43,7 +51,7 @@ def test_unimplemented_user_datastore_methods():
 
 
 def test_toggle_active():
-    datastore = UserDatastore(None, None)
+    datastore = MockDatastore(None, None)
     user = User()
     user.active = True
     assert datastore.toggle_active(user) is True
@@ -53,7 +61,7 @@ def test_toggle_active():
 
 
 def test_deactivate_user():
-    datastore = UserDatastore(None, None)
+    datastore = MockDatastore(None, None)
     user = User()
     user.active = True
     assert datastore.deactivate_user(user) is True
@@ -61,7 +69,7 @@ def test_deactivate_user():
 
 
 def test_activate_user():
-    datastore = UserDatastore(None, None)
+    datastore = MockDatastore(None, None)
     user = User()
     user.active = False
     assert datastore.activate_user(user) is True

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -94,7 +94,7 @@ def test_verify_password_bcrypt_rounds_too_low(app, sqlalchemy_datastore):
                 "SECURITY_PASSWORD_HASH_OPTIONS": {"bcrypt": {"rounds": 3}},
             }
         )
-    assert all(s in str(exc_msg) for s in ["rounds", "too low"])
+    assert all(s in str(exc_msg.value) for s in ["rounds", "too low"])
 
 
 def test_login_with_bcrypt_enabled(app, sqlalchemy_datastore):


### PR DESCRIPTION
- Improve documentation for :meth:`.UserDatastore.create_user` to make clear that hashed password
  should be passed in.
- Improve documentation for :class:`.UserDatastore` and :func:`.verify_and_update_password`
  to make clear that caller must commit changers to DB if using a session based datastore.
- (:issue:`122`) Clarify when to use ``confirm_register_form`` rather than ``register_form``.
- Fix bug in 2FA that didn't commit DB after using `verify_and_update_password`.
- Fix bug(s) in UserDatastore where changes to user ``active`` flag weren't being
  added to DB.

 closes: #122