### PR TITLE
Fix - json response of errors that are LazyStrings

### DIFF
--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -16,7 +16,7 @@ import inspect
 from flask import Markup, current_app, request
 from flask_login import current_user
 from flask_wtf import FlaskForm as BaseForm
-from speaklater import make_lazy_string
+from speaklater import is_lazy_string, make_lazy_string
 from wtforms import (
     BooleanField,
     Field,
@@ -78,7 +78,7 @@ class ValidatorMixin(object):
         super(ValidatorMixin, self).__init__(*args, **kwargs)
 
     def __call__(self, form, field):
-        if not self.message:
+        if not is_lazy_string(self.message) and not self.message:
             # Creat on first usage within app context.
             self.message = make_lazy_string(
                 _local_xlate, config_value("MSG_" + self._original_message)[0]

--- a/tests/test_changeable.py
+++ b/tests/test_changeable.py
@@ -16,7 +16,7 @@ from flask_security.signals import password_changed
 pytestmark = pytest.mark.changeable()
 
 
-def test_recoverable_flag(app, client, get_message):
+def test_changeable_flag(app, client, get_message):
     recorded = []
 
     @password_changed.connect_via(app)
@@ -124,6 +124,16 @@ def test_recoverable_flag(app, client, get_message):
     )
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/json"
+
+    # Test JSON errors
+    data = '{"password": "newpassword"}'
+    response = client.post(
+        "/change", data=data, headers={"Content-Type": "application/json"}
+    )
+    assert response.status_code == 400
+    assert response.jdata["response"]["errors"]["new_password"] == [
+        "Password not provided"
+    ]
 
 
 @pytest.mark.settings(change_url="/custom_change")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -430,3 +430,13 @@ def test_per_request_xlate(app, client):
     response = client.get("/change", follow_redirects=True)
     assert response.status_code == 200
     assert b"Nouveau mot de passe" in response.data
+
+    # try JSON
+    data = '{"email": "matt@lp.com"}'
+    response = client.post(
+        "/change", data=data, headers={"Content-Type": "application/json"}
+    )
+    assert response.status_code == 400
+    assert response.jdata["response"]["errors"]["new_password"] == [
+        "Merci d'indiquer un mot de passe"
+    ]


### PR DESCRIPTION
The default Flask JSONEncoder doesn't handle this.
Flask-Security unit tests/conftest simply added their own encoder!

But that of course didn't work for normal applications.
Since this really only affected error strings - simply looped through and
un-lazied them...

Also - as part of debugging - realized that 'if self.message', where
message was a LazyString - was evaluating the string every time.... fixed that.

closes: #127 