### PR TITLE
Feature - update CSRF support.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ Released TBD
 - Fix bug in 2FA that didn't commit DB after using `verify_and_update_password`.
 - Fix bug(s) in UserDatastore where changes to user ``active`` flag weren't being
   added to DB.
+- (:issue:`127`) JSON response was failing due to LazyStrings in error response.
+- (:issue:`126`, `93`, `96`) Revamp entire CSRF handling. This adds support for Single Page Applications
+  and having CSRF protection for browser(session) authentication but ignored for
+  token based authentication. Add extensive documentation about all the options.
 
 Possible compatibility issues:
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,6 +34,8 @@ Protecting Views
 
 .. autofunction:: flask_security.decorators.auth_required
 
+.. autofunction:: flask_security.decorators.unauth_csrf
+
 .. data:: @security.unauthorized_handler
 
     If an endpoint fails authentication or authorization from above decorators

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -8,121 +8,146 @@ Core
 
 .. tabularcolumns:: |p{6.5cm}|p{8.5cm}|
 
-======================================== =======================================
-``SECRET_KEY``                           This is actually part of Flask - but is used by
-                                         Flask-Security to sign all tokens.
-``SECURITY_BLUEPRINT_NAME``              Specifies the name for the
-                                         Flask-Security blueprint. Defaults to
-                                         ``security``.
-``SECURITY_CLI_USERS_NAME``              Specifies the name for the command
-                                         managing users. Disable by setting
-                                         ``False``. Defaults to ``users``.
-``SECURITY_CLI_ROLES_NAME``              Specifies the name for the command
-                                         managing roles. Disable by setting
-                                         ``False``. Defaults to ``roles``.
-``SECURITY_URL_PREFIX``                  Specifies the URL prefix for the
-                                         Flask-Security blueprint. Defaults to
-                                         ``None``.
-``SECURITY_SUBDOMAIN``                   Specifies the subdomain for the
-                                         Flask-Security blueprint. Defaults to
-                                         ``None``.
-``SECURITY_FLASH_MESSAGES``              Specifies whether or not to flash
-                                         messages during security procedures.
-                                         Defaults to ``True``.
-``SECURITY_I18N_DOMAIN``                 Specifies the name for domain
-                                         used for translations.
-                                         Defaults to ``flask_security``.
-``SECURITY_I18N_DIRNAME``                Specifies the directory containing the
-                                         ``MO`` files used for translations.
-                                         Defaults to
-                                         ``[PATH_LIB]/flask_security/translations``.
-``SECURITY_PASSWORD_HASH``               Specifies the password hash algorithm to
-                                         use when hashing passwords. Recommended
-                                         values for production systems are
-                                         ``bcrypt``, ``sha512_crypt``, or
-                                         ``pbkdf2_sha512``. Defaults to
-                                         ``bcrypt``.
-``SECURITY_PASSWORD_SCHEMES``            List of support password hash algorithms.
-                                         `SECURITY_PASSWORD_HASH` must be from this list.
-                                         Passwords encrypted with any of these schemes will be honored.
-``SECURITY_DEPRECATED_PASSWORD_SCHEMES`` List of password hash algorithms that are considered weak and
-                                         will be accepted, however on first use will be re-hased to the current
-                                         default `SECURITY_PASSWORD_HASH`.
-                                         Default is ``["auto"]`` which means any password found that wasn't
-                                         hashed using `SECURITY_PASSWORD_HASH` will be re-hashed.
-``SECURITY_PASSWORD_SALT``               Specifies the HMAC salt. Defaults to
-                                         ``None``.
-``SECURITY_PASSWORD_SINGLE_HASH``        A list of schemes that should not be hashed
-                                         twice. By default, passwords are
-                                         hashed twice, first with
-                                         ``SECURITY_PASSWORD_SALT``, and then
-                                         with a random salt.
-                                         Defaults to a list of known schemes
-                                         not working with double hashing
-                                         (`django_{digest}`, `plaintext`).
-``SECURITY_HASHING_SCHEMES``             List of algorithms used for
-                                         encrypting/hashing sensitive data within a token
-                                         (Such as is sent with confirmation or reset password).
-                                         Defaults to ``sha256_crypt``.
-``SECURITY_DEPRECATED_HASHING_SCHEMES``  List of deprecated algorithms used for
-                                         creating and validating tokens.
-                                         Defaults to ``hex_md5``.
-``SECURITY_PASSWORD_HASH_OPTIONS``       Specifies additional options to be passed
-                                         to the hashing method.
-``SECURITY_EMAIL_SENDER``                Specifies the email address to send
-                                         emails as. Defaults to value set
-                                         to ``MAIL_DEFAULT_SENDER`` if
-                                         Flask-Mail is used otherwise
-                                         ``no-reply@localhost``.
-``SECURITY_TWO_FACTOR_RESCUE_MAIL``      Specifies the email address users send
-                                         mail to when they can't complete the
-                                         two-factor authentication login.
-                                         Defaults to ``no-reply@localhost``.
-``SECURITY_TWO_FACTOR_SECRET``           Secret used to encrypt totp_password both into DB
-                                         and in session cookie. Best practice is to set this
-                                         to '{1: passlib.totp.generate_secret()}'.
-                                         See: `Totp`_ for details.
-``SECURITY_TOKEN_AUTHENTICATION_KEY``    Specifies the query string parameter to
-                                         read when using token authentication.
-                                         Defaults to ``auth_token``.
-``SECURITY_TOKEN_AUTHENTICATION_HEADER`` Specifies the HTTP header to read when
-                                         using token authentication. Defaults to
-                                         ``Authentication-Token``.
-``SECURITY_TOKEN_MAX_AGE``               Specifies the number of seconds before
-                                         an authentication token expires.
-                                         Defaults to None, meaning the token
-                                         never expires.
-``SECURITY_DEFAULT_HTTP_AUTH_REALM``     Specifies the default authentication
-                                         realm when using basic HTTP auth.
-                                         Defaults to ``Login Required``
-``SECURITY_USE_VERIFY_PASSWORD_CACHE``   If ``True`` Enables cache for token
-                                         verification, which speeds up further
-                                         calls to authenticated routes using
-                                         authentication-token and slow hash algorithms
-                                         (like bcrypt). Defaults to ``None``
-``SECURITY_VERIFY_HASH_CACHE_MAX_SIZE``  Limitation for token validation cache size
-                                         Rules are the ones of TTLCache of
-                                         cachetools package. Defaults to
-                                         ``500``
-``SECURITY_VERIFY_HASH_CACHE_TTL``       Time to live for password check cache entries.
-                                         Defaults to ``300`` (5 minutes)
-``SECURITY_REDIRECT_BEHAVIOR``           Passwordless login, confirmation, and
-                                         reset password have GET endpoints that validate
-                                         the passed token and redirect to an action form.
-                                         For Single-Page-Applications style UIs which need
-                                         to control their own internal URL routing these redirects
-                                         need to not contain forms, but contain relevant information
-                                         as query parameters. Setting this to ``spa`` will enable
-                                         that behavior. Defaults to ``None`` which is existing
-                                         html-style form redirects.
-``SECURITY_REDIRECT_HOST``               Mostly for development purposes, the UI is often developed
-                                         separately and is running on a different port than the
-                                         Flask application. In order to test redirects, the `netloc`
-                                         of the redirect URL needs to be rewritten. Setting this
-                                         to e.g. `localhost:8080` does that. Defaults to ``None``
-======================================== =======================================
+==============================================   =============================================
+``SECRET_KEY``                                   This is actually part of Flask - but is used by
+                                                 Flask-Security to sign all tokens.
+``SECURITY_BLUEPRINT_NAME``                      Specifies the name for the
+                                                 Flask-Security blueprint. Defaults to
+                                                 ``security``.
+``SECURITY_CLI_USERS_NAME``                      Specifies the name for the command
+                                                 managing users. Disable by setting
+                                                 ``False``. Defaults to ``users``.
+``SECURITY_CLI_ROLES_NAME``                      Specifies the name for the command
+                                                 managing roles. Disable by setting
+                                                 ``False``. Defaults to ``roles``.
+``SECURITY_URL_PREFIX``                          Specifies the URL prefix for the
+                                                 Flask-Security blueprint. Defaults to
+                                                 ``None``.
+``SECURITY_SUBDOMAIN``                           Specifies the subdomain for the
+                                                 Flask-Security blueprint. Defaults to
+                                                 ``None``.
+``SECURITY_FLASH_MESSAGES``                      Specifies whether or not to flash
+                                                 messages during security procedures.
+                                                 Defaults to ``True``.
+``SECURITY_I18N_DOMAIN``                         Specifies the name for domain
+                                                 used for translations.
+                                                 Defaults to ``flask_security``.
+``SECURITY_I18N_DIRNAME``                        Specifies the directory containing the
+                                                 ``MO`` files used for translations.
+                                                 Defaults to
+                                                 ``[PATH_LIB]/flask_security/translations``.
+``SECURITY_PASSWORD_HASH``                       Specifies the password hash algorithm to
+                                                 use when hashing passwords. Recommended
+                                                 values for production systems are
+                                                 ``bcrypt``, ``sha512_crypt``, or
+                                                 ``pbkdf2_sha512``. Defaults to
+                                                 ``bcrypt``.
+``SECURITY_PASSWORD_SCHEMES``                    List of support password hash algorithms.
+                                                 `SECURITY_PASSWORD_HASH` must be from this list.
+                                                 Passwords encrypted with any of these schemes will be honored.
+``SECURITY_DEPRECATED_PASSWORD_SCHEMES``         List of password hash algorithms that are considered weak and
+                                                 will be accepted, however on first use, will be re-hashed
+                                                 to the current default `SECURITY_PASSWORD_HASH`.
+                                                 Default is ``["auto"]`` which means any password found that wasn't
+                                                 hashed using `SECURITY_PASSWORD_HASH` will be re-hashed.
+``SECURITY_PASSWORD_SALT``                       Specifies the HMAC salt. Defaults to
+                                                 ``None``.
+``SECURITY_PASSWORD_SINGLE_HASH``                A list of schemes that should not be hashed
+                                                 twice. By default, passwords are
+                                                 hashed twice, first with
+                                                 ``SECURITY_PASSWORD_SALT``, and then
+                                                 with a random salt.
+                                                 Defaults to a list of known schemes
+                                                 not working with double hashing
+                                                 (`django_{digest}`, `plaintext`).
+``SECURITY_HASHING_SCHEMES``                     List of algorithms used for
+                                                 encrypting/hashing sensitive data within a token
+                                                 (Such as is sent with confirmation or reset password).
+                                                 Defaults to ``sha256_crypt``.
+``SECURITY_DEPRECATED_HASHING_SCHEMES``          List of deprecated algorithms used for
+                                                 creating and validating tokens.
+                                                 Defaults to ``hex_md5``.
+``SECURITY_PASSWORD_HASH_OPTIONS``               Specifies additional options to be passed
+                                                 to the hashing method.
+``SECURITY_EMAIL_SENDER``                        Specifies the email address to send
+                                                 emails as. Defaults to value set
+                                                 to ``MAIL_DEFAULT_SENDER`` if
+                                                 Flask-Mail is used otherwise
+                                                 ``no-reply@localhost``.
+``SECURITY_TWO_FACTOR_RESCUE_MAIL``              Specifies the email address users send
+                                                 mail to when they can't complete the
+                                                 two-factor authentication login.
+                                                 Defaults to ``no-reply@localhost``.
+``SECURITY_TWO_FACTOR_SECRET``                   Secret used to encrypt totp_password both into DB
+                                                 and in session cookie. Best practice is to set this
+                                                 to '{1: passlib.totp.generate_secret()}'.
+                                                 See: `Totp`_ for details.
+``SECURITY_TOKEN_AUTHENTICATION_KEY``            Specifies the query string parameter to
+                                                 read when using token authentication.
+                                                 Defaults to ``auth_token``.
+``SECURITY_TOKEN_AUTHENTICATION_HEADER``         Specifies the HTTP header to read when
+                                                 using token authentication. Defaults to
+                                                 ``Authentication-Token``.
+``SECURITY_TOKEN_MAX_AGE``                       Specifies the number of seconds before
+                                                 an authentication token expires.
+                                                 Defaults to None, meaning the token
+                                                 never expires.
+``SECURITY_DEFAULT_HTTP_AUTH_REALM``             Specifies the default authentication
+                                                 realm when using basic HTTP auth.
+                                                 Defaults to ``Login Required``
+``SECURITY_USE_VERIFY_PASSWORD_CACHE``           If ``True`` Enables cache for token
+                                                 verification, which speeds up further
+                                                 calls to authenticated routes using
+                                                 authentication-token and slow hash algorithms
+                                                 (like bcrypt). Defaults to ``None``
+``SECURITY_VERIFY_HASH_CACHE_MAX_SIZE``          Limitation for token validation cache size
+                                                 Rules are the ones of TTLCache of
+                                                 cachetools package. Defaults to
+                                                 ``500``
+``SECURITY_VERIFY_HASH_CACHE_TTL``               Time to live for password check cache entries.
+                                                 Defaults to ``300`` (5 minutes)
+``SECURITY_REDIRECT_BEHAVIOR``                   Passwordless login, confirmation, and
+                                                 reset password have GET endpoints that validate
+                                                 the passed token and redirect to an action form.
+                                                 For Single-Page-Applications style UIs which need
+                                                 to control their own internal URL routing these redirects
+                                                 need to not contain forms, but contain relevant information
+                                                 as query parameters. Setting this to ``spa`` will enable
+                                                 that behavior. Defaults to ``None`` which is existing
+                                                 html-style form redirects.
+``SECURITY_REDIRECT_HOST``                       Mostly for development purposes, the UI is often developed
+                                                 separately and is running on a different port than the
+                                                 Flask application. In order to test redirects, the `netloc`
+                                                 of the redirect URL needs to be rewritten. Setting this
+                                                 to e.g. `localhost:8080` does that. Defaults to ``None``
+``SECURITY_CSRF_PROTECT_MECHANISMS``             Authentication mechanisms that require CSRF protection.
+                                                 These are the same mechanisms as are permitted
+                                                 in the ``@auth_required`` decorator.
+                                                 Defaults to ``None``
+``SECURITY_CSRF_IGNORE_UNAUTH_ENDPOINTS``        If ``True`` then CSRF will not be required for endpoints
+                                                 that don't require authentication
+                                                 (e.g. login, logout, register, forgot_password).
+                                                 Defaults to ``False``
+``SECURITY_CSRF_COOKIE``                         A dict that defines the parameters required to
+                                                 set a CSRF cookie. At a minimum it requires a 'key'.
+                                                 The complete set of parameters is described in Flask's
+                                                 `set_cookie`_ documentation.
+                                                 Defaults to ``{"key": None}`` whic means no cookie will
+                                                 sent.
+``SECURITY_CSRF_HEADER``                         The HTTP Header name that will contain the CSRF token.
+                                                 ``X-XSRF-Token`` is used by packages such as `axios`_.
+                                                 Defaults to ``X-XSRF-Token``.
+``SECURITY_CSRF_COOKIE_REFRESH_EACH_REQUEST``    By default, csrf_tokens have an expiration (controlled
+                                                 the the configuration variable ``WTF_CSRF_TIME_LIMIT``.
+                                                 This can cause CSRF failures if say an application is left
+                                                 idle for a long time. You can set that time limit to ``None``
+                                                 Or have the CSRF cookie sent on every request (which will give
+                                                 it a new expiration time. Defaults to ``False``.
+==============================================   =============================================
 
 .. _Totp: https://passlib.readthedocs.io/en/stable/narr/totp-tutorial.html#totp-encryption-setup
+.. _set_cookie: https://flask.palletsprojects.com/en/1.1.x/api/?highlight=set_cookie#flask.Response.set_cookie
+.. _axios: https://github.com/axios/axios
 
 URLs and Views
 --------------

--- a/docs/contents.rst.inc
+++ b/docs/contents.rst.inc
@@ -10,6 +10,7 @@ Contents
    models
    customizing
    two_factor_configurations
+   patterns
    api
    changelog
    authors

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -12,7 +12,10 @@ Session based authentication is fulfilled entirely by the `Flask-Login`_
 extension. Flask-Security handles the configuration of Flask-Login automatically
 based on a few of its own configuration values and uses Flask-Login's
 `alternative token`_ feature for remembering users when their session has
-expired.
+expired. `Flask-WTF`_ integrates with the session as well to provide out of the box
+CSRF support. Flask-Security extends that to support requiring CSRF for
+requests that are authenticated via session cookies, but not for requests
+authenticated using tokens.
 
 
 Role/Identity Based Access
@@ -132,8 +135,9 @@ statistics. They include:
 JSON/Ajax Support
 -----------------
 
-Flask-Security supports JSON/Ajax requests where appropriate. Just remember that
-all endpoints require a CSRF token just like HTML views. More specifically
+Flask-Security supports JSON/Ajax requests where appropriate. Please
+look at :ref:`csrftopic` for details on how to work with JSON and
+Single Page Applications. More specifically
 JSON is supported for the following operations:
 
 * Login requests
@@ -158,6 +162,7 @@ Run ``flask --help`` and look for users and roles.
 
 .. _Click: http://click.pocoo.org/
 .. _Flask-Login: https://flask-login.readthedocs.org/en/latest/
+.. _Flask-WTF: https://flask-wtf.readthedocs.io/en/stable/csrf.html
 .. _alternative token: https://flask-login.readthedocs.io/en/latest/#alternative-tokens
 .. _Flask-Principal: https://pypi.org/project/Flask-Principal/
 .. _documentation on this topic: http://packages.python.org/Flask-Principal/#granular-resource-protection

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,6 +8,9 @@ info:
     Since Flask-Security is middleware, with many possible configurations this is a
     guide to how the APIs will behave using standard defaults.
 
+    By default, all POST requests require a CSRF token. This is handled automatically
+    if you render the form from your Flask application. Please read the online documentation to find out details on how CSRF can be confifgured.
+
     _Be aware that the current renderer is great! but has some limitations._
     In particular
     it can't represent both form input and JSON input - but all APIs take both. Also
@@ -25,16 +28,23 @@ info:
 paths:
   /login:
     get:
-      summary: Retrieve login form
+      summary: Retrieve login form and/or user information
       responses:
         200:
-          description: Login form
+          description: >
+            Login form or user information. The JSON response will always
+            carry the csrf_token information. If the caller is logged in, then
+            additional information is returned. This can be very useful for single-page applications where during a force refresh, all state is lost.
+            By performing this GET, the session cookie will authenticate the user and the response will contain user information.
           content:
             text/html:
               schema:
                 example: render_template(cv('LOGIN_USER_TEMPLATE')
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DefaultJsonResponse"
         302:
-          description: Response when already logged in
+          description: Response when already logged in (non-JSON request)
           headers:
             Location:
               schema:
@@ -42,7 +52,7 @@ paths:
                 example: redirect(cv('POST_LOGIN_VIEW'))
     post:
       summary: Login to application
-      description: Supports both json and form request types
+      description: Supports both json and form request types. If the caller is already logged in, they are logged out and the new user is logged in.
       parameters:
         - name: next
           in: query
@@ -88,7 +98,7 @@ paths:
                 $ref: "#/components/schemas/DefaultJsonErrorResponse"
   /login(passwordless):
     get:
-      summary: Return passwordless login form.
+      summary: Return passwordless login form
       responses:
         200:
           description: Passwordless login form
@@ -97,7 +107,7 @@ paths:
               schema:
                 example: render_template(cv('SEND_LOGIN_TEMPLATE'))
     post:
-      summary: Send passwordless login instructions email.
+      summary: Send passwordless login instructions email
       requestBody:
         required: true
         content:
@@ -133,7 +143,7 @@ paths:
         schema:
           type: string
     get:
-      summary: Login via token.
+      summary: Login via token
       description: >
         This is the result of getting a passwordless login token and is usually
         the result of clicking the link from a passwordless email.
@@ -253,7 +263,7 @@ paths:
                 $ref: "#/components/schemas/DefaultJsonErrorResponse"
   /change:
     get:
-      summary: Return change password form.
+      summary: Return change password form
       responses:
         200:
           description: change password form
@@ -262,7 +272,12 @@ paths:
               schema:
                 example: render_template(cv('CHANGE_PASSWORD_TEMPLATE'))
     post:
-      summary: Change password.
+      summary: Change password
+      parameters:
+        - name: X-CSRF-Token
+          in: header
+          schema:
+            $ref: "#/components/headers/X-CSRF-Token"
       requestBody:
         required: true
         content:
@@ -300,7 +315,7 @@ paths:
                 $ref: "#/components/schemas/DefaultJsonErrorResponse"
   /reset:
     get:
-      summary: Return reset password form.
+      summary: Return reset password form
       responses:
         200:
           description: Reset password form
@@ -316,7 +331,7 @@ paths:
                 type: string
                 example: redirect(cv('POST_LOGIN_VIEW'))
     post:
-      summary: Send reset password instructions email.
+      summary: Send reset password instructions email
       requestBody:
         required: true
         content:
@@ -352,7 +367,7 @@ paths:
         schema:
           type: string
     get:
-      summary: Request to reset password.
+      summary: Request to reset password
       description: >
         This is the result of getting a reset-password token and is usually
         the result of clicking the link from a reset-password email.
@@ -390,7 +405,7 @@ paths:
                 default-error:
                   value: redirect(cv('FORGOT_PASSWORD'))
     post:
-      summary: Reset password.
+      summary: Reset password
       requestBody:
         required: true
         content:
@@ -402,7 +417,7 @@ paths:
               $ref: "#/components/schemas/ResetPassword"
       responses:
         200:
-          description: Reset response.
+          description: Reset response
           content:
             text/html:
               schema:
@@ -436,7 +451,7 @@ paths:
                 $ref: "#/components/schemas/DefaultJsonErrorResponse"
   /confirm:
     get:
-      summary: Return send confirmation form.
+      summary: Return send confirmation form
       responses:
         200:
           description: Confirmation form
@@ -445,7 +460,7 @@ paths:
               schema:
                 example: render_template(cv('SEND_CONFIRMATION_TEMPLATE'))
     post:
-      summary: Send confirmation email.
+      summary: Send confirmation email
       requestBody:
         required: true
         content:
@@ -481,7 +496,7 @@ paths:
         schema:
           type: string
     get:
-      summary: Request to confirm account.
+      summary: Request to confirm account
       description: >
         This is the result of getting a confirmation token and is usually
         the result of clicking the link from a confirmation email.
@@ -538,7 +553,7 @@ components:
           type: object
           required: [id]
           description: >
-            By default just 'id' and 'authentication_token' are returned. However by overriding _User::get_security_payload()_ any attributes of the User model can be returned.
+            By default just 'id', and 'authentication_token' are returned. However by overriding _User::get_security_payload()_ any attributes of the User model can be returned.
           properties:
             id:
               type: integer
@@ -547,6 +562,9 @@ components:
             authentication_token:
               type: string
               description: Token to be used in future token-based API calls.
+        csrf_token:
+          type: string
+          description: Session CSRF token
     DefaultJsonErrorResponse:
       type: object
       required: [meta, response]
@@ -617,10 +635,8 @@ components:
           description: Password - again
     ChangePassword:
       type: object
-      required: [email, password, new_password, new_password_confirm]
+      required: [password, new_password, new_password_confirm]
       properties:
-        email:
-          type: string
         password:
           type: string
           description: Password
@@ -638,3 +654,8 @@ components:
           type: string
           description: >
             Email address to send link email to.
+  headers:
+    X-CSRF-Token:
+      schema:
+        type: string
+

--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -1,0 +1,166 @@
+Security Patterns
+=================
+
+.. _csrftopic:
+
+CSRF
+~~~~
+By default, Flask-Security, via Flask-WTForms protects all form based POSTS
+from CSRF attacks using well vetted per-session hidden-form-field csrf-tokens.
+
+Any web application that relies on session cookies for authentication must have CSRF protection.
+For more details please read this `OWASP cheatsheet <https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md>`_.
+A couple important take-aways - first - it isn't about forms versus JSON - it is about
+how the API is authenticated (session cookies versus authentication token). Second there is the
+concern about 'login CSRF' - is protection needed prior to authentication (yes if
+you have a really secure/popular site).
+
+Flask-Security strives to support various options for both its endpoints (e.g. ``/login``)
+and the application endpoints (protected with Flask-Security decorators such as ``@auth_required``).
+
+If your application just uses forms that are derived from ``Flask-WTF::Flaskform`` - you are done.
+
+
+CSRF: Single-Page-Applications and AJAX/XHR
+++++++++++++++++++++++++++++++++++++++++++++
+If you are thinking about using authentication tokens in your browser-based UI - read
+`This article <https://stormpath.com/blog/where-to-store-your-jwts-cookies-vs-html5-web-storage>`_
+on how and where to store authentication tokens. While the
+article is talking about JWT it applies to flask_security tokens as well.
+
+In general, it is considered more secure (and easier) to use sessions for browser
+based UI, and tokens for service to service and scripts.
+
+For SPA, and especially those that aren't served via your flask application, there are difficulties
+with actually retrieving and using a CSRF token. There are 2 normal ways to do this:
+
+ * Have the csrf-token available via a JSON GET request that can be attached as a
+   header in every mutating request.
+ * Have a cookie that can be read via javascript whose value is the csrf-token that
+   can be attached as a header in every mutating request.
+
+Flask-Security supports both solutions.
+
+Explicit fetch and send of csrf-token
+--------------------------------------
+The current session CSRF token
+is returned on every JSON GET request (to a Flask-Security endpoint) as ``response['csrf_token`]``.
+For web applications that ARE served via flask, it is even easier to get the csrf-token -
+`<https://flask-wtf.readthedocs.io/en/stable/csrf.html>`_ gives some useful tips.
+
+Armed with the csrf-token, the UI must include that in every mutating operation.
+Be careful NOT to include the csrf-token in non-mutating requests (such as GETs).
+If your application uses GET to actually modify state - please stop.
+
+An example using `axios <https://github.com/axios/axios>`_ ::
+
+
+    # This will fetch the csrf-token. Note that we do a GET on the login endpoint
+    # which will get us the csrf-token even though we aren't yet logged in.
+    # Note further the 'data: null' and explicit Content-Type header - these are
+    # critical, otherwise Flask-Security will return the login form.
+    axios.get('/login',{data: null, headers: {'Content-Type': 'application/json'}}).then(function (resp) {
+      csrf_token = resp.data['response']['csrf_token']
+    })
+
+
+    # This will add the token header to each outgoing mutating request.
+    axios.interceptors.request.use(function (config) {
+      if (["post", "delete", "patch", "put"].includes(config["method"])) {
+        if (csrf_token !== '') {
+          config.headers["X-CSRF-Token"] = csrf_token
+        }
+      }
+      return config;
+    }, function (error) {
+      // Do something with request error
+      return Promise.reject(error);
+    });
+
+
+
+Note that we use the header name ``X-CSRF-Token`` as that is one of the default
+headers configured in Flask-WTF (``WTF_CSRF_HEADERS``)
+
+To protect your application's endpoints (that presumably are not using Flask forms),
+you need to enable CSRF as described in the FlaskWTF `documentation <https://flask-wtf.readthedocs.io/en/stable/csrf.html>`_: ::
+
+    flask_wtf.CSRFProtect(app)
+
+This will turn on CSRF protection on ALL endpoints, including Flask-Security. This protection differs slightly from
+the default that is part of FlaskForm in that it will first look at the request body and see if it can find a form field that contains
+the csrf-token, and if it can't, it will check if the request has a header that is listed in ``WTF_CSRF_HEADERS`` and use that.
+Be aware that if you enable this it will ONLY work if you send the session cookie on each request.
+
+Using a Cookie
+--------------
+You can instruct Flask-Security to send a cookie that contains the csrf token. This can be very
+convenient since various javascript AJAX packages are pre-configured to extract the contents of a cookie
+and send it on every mutating request as an HTTP header. `axios`_ for example has a default configuration
+that it will look for a cookie named ``XSRF-TOKEN`` and will send the contents of that back
+in an HTTP header called ``X-XSRF-Token``. This means that if you use that package you don't need to make
+any changes to your UI and just need the following configuration::
+
+    # Have cookie sent
+    app.config["SECURITY_CSRF_COOKIE"] = {"key": "XSRF-TOKEN"}
+
+    # Don't have csrf tokens expire (they are invalid after logout)
+    app.config["WTF_CSRF_TIME_LIMIT"] = None
+
+    # You can't get the cookie until you are logged in.
+    app.config["SECURITY_CSRF_IGNORE_UNAUTH_ENDPOINTS"] = True
+
+    # Enable CSRF protection
+    flask_wtf.CSRFProtect(app)
+
+Angular's `httpClient`_ also supports this.
+
+
+CSRF: Enable protection for session auth, but not token auth
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+As mentioned above, CSRF is critical for any mutating operation where the authentication credentials are 'invisibly' sent - such as a session cookie -
+from a browser. But if your endpoint a) can only be authenticated with an attached token or b) can be called either via session OR token;
+it is often desirable not to force token API users to deal with CSRF. To solve this, we need to keep CSRFProtect from checking the csrf-token early in the
+request and instead defer that decision to later decorators/code. Flask-Security's authentication decorators (``auth_required``, ``auth_token_required``,
+and ``http_auth_required`` all support calling csrf protection based on configuration::
+
+    # Disable pre-request CSRF
+    app.config[WTF_CSRF_CHECK_DEFAULT] = False
+
+    # Check csrf for session and http auth (but not token)
+    app.config[SECURITY_CSRF_PROTECT_MECHANISMS] = ["session", "basic"]
+
+    # Enable CSRF protection
+    flask_wtf.CSRFProtect(app)
+
+    @app.route("/")
+    @auth_required("token", "session")
+    def home_page():
+
+With this configuration, CSRF won't be required if the caller uses an authentication token, but if it uses
+the session cookie it will.
+
+CSRF: Pro-Tips
+++++++++++++++
+    #) Be aware that for CSRF to work, callers MUST send the session cookie. So
+       for pure API, and no session cookie - there is no way to support 'login CSRF'.
+       So your app must set ``SECURITY_CSRF_IGNORE_UNAUTH_ENDPOINTS``
+       (or clients must use CSRF/session cookie for logging
+       in then once they have an authentication token, no further need for cookie).
+
+    #) If you enable CSRFProtect(app) and you want to support non-form based JSON requests,
+       then you must include the CSRF token in the header (e.g. X-CSRF-Token)
+
+    #) You must enable CSRFProtect(app) if you want to accept the CSRF token in the request
+       header.
+
+    #) Consider starting by setting ``SECURITY_CSRF_IGNORE_UNAUTH_ENDPOINTS`` to True. Your
+       application likely doesn't need 'login CSRF' protection, and it is frustrating
+       to not even be able to login via API!
+
+    #) If you have unauthenticated endpoints that you want to protect with CSRF then
+       use the ``@unauth_csrf`` decorator.
+
+
+.. _axios: https://github.com/axios/axios
+.. _httpClient: https://angular.io/guide/http#security-xsrf-protection

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -555,6 +555,15 @@ def client(request, sqlalchemy_app):
     return app.test_client()
 
 
+@pytest.fixture()
+def client_nc(request, sqlalchemy_app):
+    # useful for testing token auth.
+    # No Cookies for You!
+    app = sqlalchemy_app()
+    populate_data(app)
+    return app.test_client(use_cookies=False)
+
+
 @pytest.yield_fixture()
 def in_app_context(request, sqlalchemy_app):
     app = sqlalchemy_app()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -425,3 +425,15 @@ def test_json_not_dict(client):
         headers={"Content-Type": "application/json"},
     )
     assert response.status_code == 200
+
+
+def test_login_info(client):
+    # Make sure we can get user info when logged in already.
+
+    json_authenticate(client)
+    response = client.get(
+        "/login", data={}, headers={"Content-Type": "application/json"}
+    )
+    assert response.status_code == 200
+    assert response.jdata["response"]["user"]["id"] == "1"
+    assert "last_update" in response.jdata["response"]["user"]

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -1,0 +1,510 @@
+# -*- coding: utf-8 -*-
+"""
+    test_csrf
+    ~~~~~~~~~~~~~~~~~
+
+    CSRF tests
+
+    :copyright: (c) 2019 by J. Christopher Wagner (jwag).
+    :license: MIT, see LICENSE for more details.
+"""
+from contextlib import contextmanager
+import time
+
+import flask_wtf.csrf
+
+from flask import json
+import pytest
+from flask_wtf import CSRFProtect
+
+from utils import get_session, logout
+
+
+REAL_VALIDATE_CSRF = None
+
+
+@contextmanager
+def mp_validate_csrf():
+    """ Make sure we are really calling CSRF validation and getting correct answer """
+    orig_validate_csrf = flask_wtf.csrf.validate_csrf
+    try:
+        mp = MpValidateCsrf(orig_validate_csrf)
+        flask_wtf.csrf.validate_csrf = mp.mp_validate_csrf
+        yield mp
+    finally:
+        flask_wtf.csrf.validate_csrf = orig_validate_csrf
+
+
+class MpValidateCsrf(object):
+    success = 0
+    failure = 0
+
+    def __init__(self, real_validate_csrf):
+        MpValidateCsrf.success = 0
+        MpValidateCsrf.failure = 0
+        global REAL_VALIDATE_CSRF
+        REAL_VALIDATE_CSRF = real_validate_csrf
+
+    @staticmethod
+    def mp_validate_csrf(data, secret_key=None, time_limit=None, token_key=None):
+
+        try:
+            REAL_VALIDATE_CSRF(data, secret_key, time_limit, token_key)
+            MpValidateCsrf.success += 1
+        except Exception:
+            MpValidateCsrf.failure += 1
+            raise
+
+
+def _get_csrf_token(client):
+    response = client.get(
+        "/login", data={}, headers={"Content-Type": "application/json"}
+    )
+    return response.jdata["response"]["csrf_token"]
+
+
+def json_login(
+    client, email="matt@lp.com", password="password", endpoint=None, use_header=False
+):
+    """ Return tuple (auth_token, csrf_token)
+    Note that since this is sent as JSON rather than form that csrfProtect
+    won't find token value (since it looks in request.form).
+    """
+    csrf_token = _get_csrf_token(client)
+    data = dict(email=email, password=password)
+
+    if use_header:
+        headers = {"X-CSRF-Token": csrf_token}
+    else:
+        headers = {}
+        data["csrf_token"] = csrf_token
+
+    response = client.post(
+        endpoint or "/login",
+        content_type="application/json",
+        data=json.dumps(data),
+        headers=headers,
+    )
+    assert response.status_code == 200
+    rd = response.jdata["response"]
+    return rd["user"]["authentication_token"], rd["csrf_token"]
+
+
+def json_logout(client):
+    response = client.post("logout", content_type="application/json", data={})
+    assert response.status_code == 200
+    assert response.jdata["meta"]["code"] == 200
+    return response
+
+
+def test_login_csrf(app, client):
+    app.config["WTF_CSRF_ENABLED"] = True
+
+    # This shouldn't log in - but return login form with csrf token.
+    data = dict(email="matt@lp.com", password="password", remember="y")
+    response = client.post("/login", data=data)
+    assert response.status_code == 200
+    assert b"csrf_token" in response.data
+
+    data["csrf_token"] = _get_csrf_token(client)
+    response = client.post("/login", data=data, follow_redirects=True)
+    assert response.status_code == 200
+    assert b"Welcome matt" in response.data
+
+    response = logout(client, follow_redirects=True)
+    assert response.status_code == 200
+    assert b"Log in" in response.data
+
+
+def test_login_csrf_json(app, client):
+    app.config["WTF_CSRF_ENABLED"] = True
+
+    with mp_validate_csrf() as mp:
+        auth_token, csrf_token = json_login(client)
+        assert auth_token
+        assert csrf_token
+    # Should be just one call to validate - since CSRFProtect not enabled.
+    assert mp.success == 1 and mp.failure == 0
+
+    response = json_logout(client)
+    session = get_session(response)
+    assert "csrf_token" not in session
+
+
+def test_login_csrf_json_header(app, client):
+    app.config["WTF_CSRF_ENABLED"] = True
+    CSRFProtect(app)
+
+    with mp_validate_csrf() as mp:
+        auth_token, csrf_token = json_login(client, use_header=True)
+        assert auth_token
+        assert csrf_token
+    assert mp.success == 2 and mp.failure == 0
+    json_logout(client)
+
+
+@pytest.mark.settings(csrf_ignore_unauth_endpoints=True)
+def test_login_csrf_unauth_ok(app, client):
+    app.config["WTF_CSRF_ENABLED"] = True
+
+    with mp_validate_csrf() as mp:
+        # This should log in.
+        data = dict(email="matt@lp.com", password="password", remember="y")
+        response = client.post("/login", data=data, follow_redirects=True)
+        assert response.status_code == 200
+        assert b"Welcome matt" in response.data
+    assert mp.success == 0 and mp.failure == 0
+    logout(client)
+
+
+@pytest.mark.settings(csrf_ignore_unauth_endpoints=True)
+def test_login_csrf_unauth_ok_double(app, client):
+    # Test can login w/o CSRF even if already logged in.
+    app.config["WTF_CSRF_ENABLED"] = True
+
+    # This should log in.
+    data = dict(email="matt@lp.com", password="password", remember="y")
+    response = client.post("/login", data=data, follow_redirects=True)
+    assert response.status_code == 200
+    assert b"Welcome matt" in response.data
+
+    # login in again - should work
+    response = client.post(
+        "/login", content_type="application/json", data=json.dumps(data)
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.recoverable()
+def test_reset(app, client):
+    """ Test that form-based CSRF works for /reset """
+    app.config["WTF_CSRF_ENABLED"] = True
+
+    with mp_validate_csrf() as mp:
+        data = dict(email="matt@lp.com")
+        # should fail - no CSRF token
+        response = client.post(
+            "/reset", content_type="application/json", data=json.dumps(data)
+        )
+        assert response.status_code == 400
+
+        data["csrf_token"] = _get_csrf_token(client)
+        response = client.post(
+            "/reset", content_type="application/json", data=json.dumps(data)
+        )
+        assert response.status_code == 200
+    assert mp.success == 1 and mp.failure == 1
+
+
+@pytest.mark.recoverable()
+def test_cp_reset(app, client):
+    """ Test that header based CSRF works for /reset when
+    using WTF_CSRF_CHECK_DEFAULT=False.
+    """
+    app.config["WTF_CSRF_ENABLED"] = True
+    app.config["WTF_CSRF_CHECK_DEFAULT"] = False
+    CSRFProtect(app)
+
+    with mp_validate_csrf() as mp:
+        data = dict(email="matt@lp.com")
+        # should fail - no CSRF token
+        response = client.post(
+            "/reset", content_type="application/json", data=json.dumps(data)
+        )
+        assert response.status_code == 400
+
+        csrf_token = _get_csrf_token(client)
+        response = client.post(
+            "/reset",
+            content_type="application/json",
+            data=json.dumps(data),
+            headers={"X-CSRF-Token": csrf_token},
+        )
+        assert response.status_code == 200
+    # 2 failures since the first time it will check twice - once due to @unauth_csrf
+    # which will fall-through on error to form validation (which also fails).
+    assert mp.success == 1 and mp.failure == 2
+
+
+@pytest.mark.changeable()
+def test_cp_with_token(app, client):
+    # Make sure can use returned CSRF-Token in Header.
+    app.config["WTF_CSRF_ENABLED"] = True
+    CSRFProtect(app)
+
+    auth_token, csrf_token = json_login(client, use_header=True)
+
+    # make sure returned csrf_token works in header.
+    data = dict(
+        password="password",
+        new_password="newpassword",
+        new_password_confirm="newpassword",
+    )
+
+    with mp_validate_csrf() as mp:
+        response = client.post(
+            "/change",
+            content_type="application/json",
+            data=json.dumps(data),
+            headers={"X-CSRF-Token": csrf_token},
+        )
+        assert response.status_code == 200
+    assert mp.success == 1 and mp.failure == 0
+    json_logout(client)
+
+
+def test_cp_login_json_no_session(app, client_nc):
+    # Test with global CSRFProtect on and not sending cookie - nothing works.
+    app.config["WTF_CSRF_ENABLED"] = True
+    CSRFProtect(app)
+
+    # This shouldn't log in - and will return 400
+    with mp_validate_csrf() as mp:
+
+        data = dict(email="matt@lp.com", password="password", remember="y")
+        response = client_nc.post(
+            "/login",
+            content_type="application/json",
+            data=json.dumps(data),
+            headers={"Accept": "application/json"},
+        )
+        assert response.status_code == 400
+
+        # This still wont work since we don't send a session cookie
+        response = client_nc.post(
+            "/login",
+            content_type="application/json",
+            data=json.dumps(data),
+            headers={"X-CSRF-Token": _get_csrf_token(client_nc)},
+        )
+        assert response.status_code == 400
+
+    # Although failed - CSRF should have been called
+    assert mp.failure == 2
+
+
+@pytest.mark.settings(CSRF_PROTECT_MECHANISMS=["basic", "session"])
+def test_cp_config(app, client):
+    # Test improper config (must have WTF_CSRF_CHECK_DEFAULT false if setting
+    # CSRF_PROTECT_MECHANISMS
+    app.config["WTF_CSRF_ENABLED"] = True
+    CSRFProtect(app)
+
+    # The check is done on first request.
+    with pytest.raises(ValueError) as ev:
+        logout(client)
+    assert "must be set to False" in str(ev.value)
+
+
+@pytest.mark.settings(CSRF_PROTECT_MECHANISMS=["basic", "session"])
+def test_cp_config2(app, client):
+    # Test improper config (must have CSRFProtect configured if setting
+    # CSRF_PROTECT_MECHANISMS
+    app.config["WTF_CSRF_ENABLED"] = True
+
+    # The check is done on first request.
+    with pytest.raises(ValueError) as ev:
+        logout(client)
+    assert "CsrfProtect not part of application" in str(ev.value)
+
+
+@pytest.mark.changeable()
+@pytest.mark.settings(CSRF_PROTECT_MECHANISMS=["basic", "session"])
+def test_different_mechanisms(app, client):
+    # Verify that using token doesn't require CSRF, but sessions do
+    app.config["WTF_CSRF_ENABLED"] = True
+    app.config["WTF_CSRF_CHECK_DEFAULT"] = False
+    CSRFProtect(app)
+
+    with mp_validate_csrf() as mp:
+        auth_token, csrf_token = json_login(client)
+
+        # session based change password should fail
+        data = dict(
+            password="password",
+            new_password="newpassword",
+            new_password_confirm="newpassword",
+        )
+
+        response = client.post(
+            "/change",
+            data=json.dumps(data),
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 400
+        assert b"The CSRF token is missing" in response.data
+
+        # token based should work
+        response = client.post(
+            "/change",
+            data=json.dumps(data),
+            headers={
+                "Content-Type": "application/json",
+                "Authentication-Token": auth_token,
+            },
+        )
+        assert response.status_code == 200
+    assert mp.success == 1 and mp.failure == 2
+
+
+@pytest.mark.changeable()
+@pytest.mark.settings(
+    CSRF_PROTECT_MECHANISMS=["basic", "session"], csrf_ignore_unauth_endpoints=True
+)
+def test_different_mechanisms_nc(app, client_nc):
+    # Verify that using token and no session cookie works
+    # Note that we had to disable unauth_endpoints since you can't log in
+    # w/ CSRF if you don't send in the session cookie.
+    app.config["WTF_CSRF_ENABLED"] = True
+    app.config["WTF_CSRF_CHECK_DEFAULT"] = False
+    CSRFProtect(app)
+
+    with mp_validate_csrf() as mp:
+        auth_token, csrf_token = json_login(client_nc)
+
+        # token based should work
+        data = dict(
+            password="password",
+            new_password="newpassword",
+            new_password_confirm="newpassword",
+        )
+        response = client_nc.post(
+            "/change",
+            data=json.dumps(data),
+            headers={
+                "Content-Type": "application/json",
+                "Authentication-Token": auth_token,
+            },
+        )
+        assert response.status_code == 200
+    assert mp.success == 0 and mp.failure == 0
+
+
+@pytest.mark.settings(
+    csrf_ignore_unauth_endpoints=True, CSRF_COOKIE={"key": "X-XSRF-Token"}
+)
+def test_csrf_cookie(app, client):
+    app.config["WTF_CSRF_ENABLED"] = True
+    app.config["WTF_CSRF_CHECK_DEFAULT"] = False
+    CSRFProtect(app)
+
+    json_login(client)
+    found = False
+    for cookie in client.cookie_jar:
+        if cookie.name == "X-XSRF-Token":
+            found = True
+            assert cookie.path == "/"
+    assert found
+
+    # Make sure cleared on logout
+    response = client.post("/logout", content_type="application/json")
+    assert response.status_code == 200
+    assert "X-XSRF-Token" not in [c.name for c in client.cookie_jar]
+
+
+@pytest.mark.settings(CSRF_COOKIE={"key": "X-XSRF-Token"})
+@pytest.mark.changeable()
+def test_cp_with_token_cookie(app, client):
+    # Make sure can use returned CSRF-Token cookie in Header.
+    app.config["WTF_CSRF_ENABLED"] = True
+    CSRFProtect(app)
+
+    json_login(client, use_header=True)
+
+    # make sure returned csrf_token works in header.
+    data = dict(
+        password="password",
+        new_password="newpassword",
+        new_password_confirm="newpassword",
+    )
+    csrf_token = [c.value for c in client.cookie_jar if c.name == "X-XSRF-Token"][0]
+    with mp_validate_csrf() as mp:
+        response = client.post(
+            "/change",
+            content_type="application/json",
+            data=json.dumps(data),
+            headers={"X-XSRF-Token": csrf_token},
+        )
+        assert response.status_code == 200
+    # 2 successes since the utils:csrf_cookie_handler will check
+    assert mp.success == 2 and mp.failure == 0
+    json_logout(client)
+    assert "X-XSRF-Token" not in [c.name for c in client.cookie_jar]
+
+
+@pytest.mark.settings(
+    CSRF_COOKIE={"key": "X-XSRF-Token"}, csrf_ignore_unauth_endpoints=True
+)
+@pytest.mark.changeable()
+def test_cp_with_token_cookie_expire(app, client):
+    # Make sure that we get a new Csrf-Token cookie if expired.
+    app.config["WTF_CSRF_ENABLED"] = True
+    app.config["WTF_CSRF_TIME_LIMIT"] = 1
+    app.config["WTF_CSRF_CHECK_DEFAULT"] = False
+    CSRFProtect(app)
+
+    json_login(client, use_header=True)
+
+    # sleep so make csrf_token expires
+    time.sleep(2)
+    data = dict(
+        password="password",
+        new_password="newpassword",
+        new_password_confirm="newpassword",
+    )
+    csrf_token = [c.value for c in client.cookie_jar if c.name == "X-XSRF-Token"][0]
+    with mp_validate_csrf() as mp:
+        response = client.post(
+            "/change",
+            content_type="application/json",
+            data=json.dumps(data),
+            headers={"X-XSRF-Token": csrf_token},
+        )
+        assert response.status_code == 400
+        assert b"expired" in response.data
+
+        # Should have gotten a new CSRF cookie value
+        new_csrf_token = [
+            c.value for c in client.cookie_jar if c.name == "X-XSRF-Token"
+        ][0]
+        assert csrf_token != new_csrf_token
+    # 2 failures since the utils:csrf_cookie_handler will check
+    assert mp.success == 0 and mp.failure == 2
+    json_logout(client)
+    assert "X-XSRF-Token" not in [c.name for c in client.cookie_jar]
+
+
+@pytest.mark.settings(
+    CSRF_COOKIE={"key": "X-XSRF-Token"}, CSRF_COOKIE_REFRESH_EACH_REQUEST=True
+)
+@pytest.mark.changeable()
+def test_cp_with_token_cookie_refresh(app, client):
+    # Test CSRF_COOKIE_REFRESH_EACH_REQUEST
+    app.config["WTF_CSRF_ENABLED"] = True
+    CSRFProtect(app)
+
+    json_login(client, use_header=True)
+
+    # make sure returned csrf_token works in header.
+    data = dict(
+        password="password",
+        new_password="newpassword",
+        new_password_confirm="newpassword",
+    )
+
+    csrf_cookie = [c for c in client.cookie_jar if c.name == "X-XSRF-Token"][0]
+    with mp_validate_csrf() as mp:
+        # Delete cookie - we should always get a new one
+        client.delete_cookie(csrf_cookie.domain, csrf_cookie.name)
+        response = client.post(
+            "/change",
+            content_type="application/json",
+            data=json.dumps(data),
+            headers={"X-XSRF-Token": csrf_cookie.value},
+        )
+        assert response.status_code == 200
+        csrf_cookie = [c for c in client.cookie_jar if c.name == "X-XSRF-Token"][0]
+        assert csrf_cookie
+    assert mp.success == 1 and mp.failure == 0
+    json_logout(client)
+    assert "X-XSRF-Token" not in [c.name for c in client.cookie_jar]


### PR DESCRIPTION
With the help of Flask-WTF - when using forms (both GET and POST) CSRF
protection was handled transparently.

However this didn't work will with pure token based authentication or
when sending requests in via JSON and had enabled site-wide CSRF
protection via Flask-WTF:CSRFProtect.

This change adds considerable flexibility when working with CSRF as well
as a new set of application notes around CSRF.

- You can configure flask-security to enforce CSRF for session based auth but allow
  token based auth to not require CSRF (this is the common use case for applications
  that support a browser-based UI as well as a pure JSON API)

- Extended the response for JSON requests to include the session csrf-token which can
  then be used in the X-CSRF-Token request header.

- Extended the flask-security authn decorators to run CSRF protection based on authn types.

- Added a configuration variable CSRF_IGNORE_UNAUTH_ENDPOINTS to make it easy to turn off
  so-called login CSRF protection (which most applications really don't need).

- Fix issue where on logout the csrf-token wasn't being cleared from the session cookie.

- Fix issue where change_password didn't work with token authn.

- Allow accessing /login endpoint even if logged in. For GETs - this is a way to
  get csrf_token as well as getting user info based on session cookie.

- Add option to send a cookie with csrf_token - this is what axios and angular want to
  automagically send a CSRF header.

closes: #93, #96, #126