### PR TITLE
Fix - deactivating user should disallow access.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Released TBD
 - (:issue:`126`, `93`, `96`) Revamp entire CSRF handling. This adds support for Single Page Applications
   and having CSRF protection for browser(session) authentication but ignored for
   token based authentication. Add extensive documentation about all the options.
+- (:issue:`117`) Making a user inactive should stop all access immediately.
 
 Possible compatibility issues:
 

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -321,7 +321,10 @@ _default_forms = {
 
 
 def _user_loader(user_id):
-    return _security.datastore.find_user(id=user_id)
+    user = _security.datastore.find_user(id=user_id)
+    if not user or not user.active:
+        return None
+    return user
 
 
 def _request_loader(request):
@@ -341,6 +344,8 @@ def _request_loader(request):
             token, max_age=_security.token_max_age
         )
         user = _security.datastore.find_user(id=data[0])
+        if not user.active:
+            user = None
     except Exception:
         user = None
 

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -203,6 +203,10 @@ class UserDatastore(object):
     def deactivate_user(self, user):
         """Deactivates a specified user. Returns `True` if a change was made.
 
+        This will immediately disallow access to all endpoints that require
+        authentication either via session or tokens.
+        The user will not be able to log in again.
+
         :param user: The user to deactivate
         """
         if user.active:

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -198,6 +198,8 @@ def auth_required(*auth_methods):
         "basic": lambda: _check_http_auth(),
     }
     mechanisms_order = ["token", "session", "basic"]
+    if not auth_methods:
+        auth_methods = ("basic", "session", "token")
 
     def wrapper(fn):
         @wraps(fn)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -31,6 +31,7 @@ class MockUser:
     def __init__(self, id, password):
         self.id = id
         self.password = password
+        self.active = True
 
 
 class MockExtensionSecurity:


### PR DESCRIPTION
Deactivating a user used to keep the user from logging in - but existing sessions and tokens
would continue to work. That's a security issue since tokens especially might be valid for a long time.

Closes #117