### PR TITLE
Fix - don't allow re-use of confirmation token.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -404,9 +404,16 @@ Miscellaneous
                                               user has before a login link
                                               expires. This is only used when
                                               the passwordless login feature is
-                                              enabled. Always pluralized the
+                                              enabled. Always pluralize the
                                               time unit for this value.
                                               Defaults to ``1 days``.
+``SECURITY_AUTO_LOGIN_AFTER_CONFIRM``         If ``False`` then on confirmation
+                                              the user will be required to login again. Note that the
+                                              confirmation token is not valid after being used once.
+                                              If ``True``, then the user corresponding to the
+                                              confirmation token will be automatically logged
+                                              in.
+                                              Defaults to ``True``.
 ``SECURITY_TWO_FACTOR_GOOGLE_AUTH_VALIDITY``  Specifies the number of seconds access token is
                                               valid. Defaults to 2 minutes.
 ``SECURITY_TWO_FACTOR_MAIL_VALIDITY``         Specifies the number of seconds

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -501,6 +501,8 @@ paths:
         This is the result of getting a confirmation token and is usually
         the result of clicking the link from a confirmation email.
         This ALWAYS results in a 302 redirect.
+        By default (unless cv('AUTO_LOGIN_AFTER_CONFIRM') == False), the user
+        denoted by the token is logged in as a side-effect.
       responses:
         302:
           description: >
@@ -509,8 +511,7 @@ paths:
           headers:
             Location:
               description: |
-                On spa-success: cv('POST_CONFIRM_VIEW')?email={email}&{level}={msg} or
-                                cv('POST_LOGIN_VIEW')?email={email}&{level}={msg}
+                On spa-success: cv('POST_CONFIRM_VIEW')?email={email}&{level}={msg}
 
                 On spa-error-expired: cv('CONFIRM_ERROR_VIEW')?error={msg}&email={email}
 
@@ -518,6 +519,9 @@ paths:
 
                 On form-success: cv('POST_CONFIRM_VIEW') or
                                  cv('POST_LOGIN_VIEW')
+                                 
+                On form-success (no auto-login): cv('POST_CONFIRM_VIEW') or
+                                 cv('LOGIN_URL')
 
                 On form-error-expired: cv('CONFIRM_ERROR_VIEW') or
                                        cv('CONFIRM_URL')

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -153,6 +153,7 @@ _default_config = {
     "CONFIRM_EMAIL_WITHIN": "5 days",
     "RESET_PASSWORD_WITHIN": "5 days",
     "LOGIN_WITHOUT_CONFIRMATION": False,
+    "AUTO_LOGIN_AFTER_CONFIRM": True,
     "EMAIL_SENDER": LocalProxy(
         lambda: current_app.config.get("MAIL_DEFAULT_SENDER", "no-reply@localhost")
     ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,10 @@ def app(request):
     def post_register():
         return render_template("index.html", content="Post Register")
 
+    @app.route("/post_confirm")
+    def post_confirm():
+        return render_template("index.html", content="Post Confirm")
+
     @app.route("/admin")
     @roles_required("admin")
     def admin():


### PR DESCRIPTION
Added option to not automatically log in user when they confirm their registration.
The default still it to log in the user.

closes #134 