### PR TITLE
Updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ sdist
 develop-eggs
 .installed.cfg
 pip-wheel-metadata/
+__pycache__/
 
 # Installer logs
 pip-log.txt
@@ -29,11 +30,14 @@ pip-log.txt
 
 #Virtualenv
 env/
+venv/
 .venv/
 
 #Editor temporaries
 *~
 
+*.swp
+*.save
 *.db
 *cache/
 
@@ -49,6 +53,9 @@ Session.vim
 
 # Mac
 .DS_Store
+
+# Linux
+.directory
 
 # Pycharm files
 .idea/


### PR DESCRIPTION
Added `__pycache__` to ignore bytecode cache, `.swp` and `.save` are editor (`vim`, `nano`) temporary files, `.directory` is generated by Dolphin and `venv/` is the default PyCharm suggests when creating a new venv.