### PR TITLE
chore - Improve docs and namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,19 +10,23 @@ Released TBD
 
 - (:pr:`120`) Native support for Permissions as part of Roles. Endpoints can be
   protected via permissions that are evaluated based on role(s) that the user has.
+- (:issue:`126`, :issue:`93`, :issue:`96`) Revamp entire CSRF handling. This adds support for Single Page Applications
+  and having CSRF protection for browser(session) authentication but ignored for
+  token based authentication. Add extensive documentation about all the options.
+- (:issue:`130`) Enable applications to provide their own :meth:`.render_json` method so that they can create
+  unified API responses.
 - Improve documentation for :meth:`.UserDatastore.create_user` to make clear that hashed password
   should be passed in.
 - Improve documentation for :class:`.UserDatastore` and :func:`.verify_and_update_password`
   to make clear that caller must commit changes to DB if using a session based datastore.
 - (:issue:`122`) Clarify when to use ``confirm_register_form`` rather than ``register_form``.
 - Fix bug in 2FA that didn't commit DB after using `verify_and_update_password`.
-- Fix bug(s) in UserDatastore where changes to user ``active`` flag weren't being
-  added to DB.
+- Fix bug(s) in UserDatastore where changes to user ``active`` flag weren't being added to DB.
 - (:issue:`127`) JSON response was failing due to LazyStrings in error response.
-- (:issue:`126`, :issue:`93`, :issue:`96`) Revamp entire CSRF handling. This adds support for Single Page Applications
-  and having CSRF protection for browser(session) authentication but ignored for
-  token based authentication. Add extensive documentation about all the options.
 - (:issue:`117`) Making a user inactive should stop all access immediately.
+- (:issue:`134`) Confirmation token can no longer be reused. Added
+  `SECURITY_AUTO_LOGIN_AFTER_CONFIRM` option for applications that don't want the user
+  to be automatically logged in after confirmation (defaults to True - existing behavior).
 
 Possible compatibility issues:
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,113 +8,112 @@ The external (json/form) API is described `here`_
 
 Core
 ----
-.. autoclass:: flask_security.core.Security
+.. autoclass:: flask_security.Security
     :members:
 
-.. data:: flask_security.core.current_user
+.. data:: flask_security.current_user
 
    A proxy for the current user.
 
 .. function:: flask_security.Security.render_json_func
 
-    A decorator for :meth:`flask_security.Security.render_json`
+    A decorator for :meth:`.Security.render_json`
+
+.. function:: flask_security.Security.unauthorized_handler
+
+    If an endpoint fails authentication or authorization from one of the decorators
+    described below
+    (except ``login_required``), a method annotated with this decorator will be called.
+    For ``login_required`` (which is implemented in Flask-Login) use
+    **flask_security.login_manager.unauthorized_handler**
 
 Protecting Views
 ----------------
-.. autofunction:: flask_security.decorators.http_auth_required
+.. autofunction:: flask_security.http_auth_required
 
-.. autofunction:: flask_security.decorators.auth_token_required
+.. autofunction:: flask_security.auth_token_required
 
-.. autofunction:: flask_security.decorators.auth_required
+.. autofunction:: flask_security.auth_required
 
-.. autofunction:: flask_security.decorators.login_required
+.. autofunction:: flask_security.login_required
 
-.. autofunction:: flask_security.decorators.roles_required
+.. autofunction:: flask_security.roles_required
 
-.. autofunction:: flask_security.decorators.roles_accepted
+.. autofunction:: flask_security.roles_accepted
 
-.. autofunction:: flask_security.decorators.permissions_required
+.. autofunction:: flask_security.permissions_required
 
-.. autofunction:: flask_security.decorators.permissions_accepted
+.. autofunction:: flask_security.permissions_accepted
 
-.. autofunction:: flask_security.decorators.unauth_csrf
+.. autofunction:: flask_security.unauth_csrf
 
-.. autofunction:: flask_security.decorators.handle_csrf
-
-.. data:: @security.unauthorized_handler
-
-    If an endpoint fails authentication or authorization from above decorators
-    (except ``login_required``), a method annotated with this decorator will be called.
-    For ``login_required`` (which is implemented in Flask-Login) use
-    **@security.login_manager.unauthorized_handler**
+.. autofunction:: flask_security.handle_csrf
 
 User Object Helpers
 -------------------
-.. autoclass:: flask_security.core.UserMixin
+.. autoclass:: flask_security.UserMixin
    :members:
 
-.. autoclass:: flask_security.core.RoleMixin
+.. autoclass:: flask_security.RoleMixin
    :members:
 
-.. autoclass:: flask_security.core.AnonymousUser
+.. autoclass:: flask_security.AnonymousUser
    :members:
 
 
 Datastores
 ----------
-.. autoclass:: flask_security.datastore.UserDatastore
+.. autoclass:: flask_security.UserDatastore
     :members:
 
-.. autoclass:: flask_security.datastore.SQLAlchemyUserDatastore
-    :members:
-    :inherited-members:
-
-.. autoclass:: flask_security.datastore.SQLAlchemySessionUserDatastore
+.. autoclass:: flask_security.SQLAlchemyUserDatastore
     :members:
     :inherited-members:
 
-.. autoclass:: flask_security.datastore.MongoEngineUserDatastore
+.. autoclass:: flask_security.SQLAlchemySessionUserDatastore
     :members:
     :inherited-members:
 
-.. autoclass:: flask_security.datastore.PeeweeUserDatastore
+.. autoclass:: flask_security.MongoEngineUserDatastore
     :members:
     :inherited-members:
 
-.. autoclass:: flask_security.datastore.PonyUserDatastore
+.. autoclass:: flask_security.PeeweeUserDatastore
+    :members:
+    :inherited-members:
+
+.. autoclass:: flask_security.PonyUserDatastore
     :members:
     :inherited-members:
 
 Utils
 -----
-.. autofunction:: flask_security.utils.login_user
+.. autofunction:: flask_security.login_user
 
-.. autofunction:: flask_security.utils.logout_user
+.. autofunction:: flask_security.logout_user
 
-.. autofunction:: flask_security.utils.get_hmac
+.. autofunction:: flask_security.get_hmac
 
-.. autofunction:: flask_security.utils.verify_password
+.. autofunction:: flask_security.verify_password
 
-.. autofunction:: flask_security.utils.verify_and_update_password
+.. autofunction:: flask_security.verify_and_update_password
 
-.. autofunction:: flask_security.utils.hash_password
+.. autofunction:: flask_security.hash_password
 
-.. autofunction:: flask_security.utils.url_for_security
+.. autofunction:: flask_security.url_for_security
 
-.. autofunction:: flask_security.utils.get_within_delta
+.. autofunction:: flask_security.send_mail
 
-.. autofunction:: flask_security.utils.send_mail
+.. autofunction:: flask_security.get_token_status
 
-.. autofunction:: flask_security.utils.get_token_status
+.. autofunction:: flask_security.get_url
 
-.. autofunction:: flask_security.utils.get_url
+.. autofunction:: flask_security.transform_url
 
-.. autofunction:: flask_security.utils.transform_url
-
-.. autoclass:: flask_security.utils.SmsSenderBaseClass
+.. autoclass:: flask_security.SmsSenderBaseClass
   :members: send_sms
 
-.. autoclass:: flask_security.utils.SmsSenderFactory
+.. autoclass:: flask_security.SmsSenderFactory
   :members: createSender
 
 Signals

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -76,7 +76,7 @@ All forms can be overridden. For each form used, you can specify a
 replacement class. This allows you to add extra fields to the
 register form or override validators::
 
-    from flask_security.forms import RegisterForm
+    from flask_security import RegisterForm
     from wtforms import StringField
     from wtforms.validators import DataRequired
 

--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -159,14 +159,14 @@ CSRF: Pro-Tips
        get control at the appropriate place.
 
     #) If you can't use a decorator, Flask-Security exposes the underlying method
-       ``handle_csrf``.
+       :func:`flask_security.handle_csrf`.
 
     #) Consider starting by setting ``SECURITY_CSRF_IGNORE_UNAUTH_ENDPOINTS`` to True. Your
        application likely doesn't need 'login CSRF' protection, and it is frustrating
        to not even be able to login via API!
 
     #) If you have unauthenticated endpoints that you want to protect with CSRF then
-       use the ``@unauth_csrf`` decorator.
+       use the :func:`flask_security.unauth_csrf` decorator.
 
 
 .. _axios: https://github.com/axios/axios

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -46,6 +46,14 @@ possible using Flask-SQLAlchemy and the built-in model mixins:
     # Bcrypt is set as default SECURITY_PASSWORD_HASH, which requires a salt
     app.config['SECURITY_PASSWORD_SALT'] = 'super-secret-random-salt'
 
+    # As of Flask-SQLAlchemy 2.4.0 it is easy to pass in options directly to the
+    # underlying engine. This option makes sure that DB connections from the
+    # pool are still valid. Important for entire application since
+    # many DBaaS options automatically close idle connections.
+    app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {
+        "pool_pre_ping": True,
+    }
+
     # Create database connection object
     db = SQLAlchemy(app)
 

--- a/docs/two_factor_configurations.rst
+++ b/docs/two_factor_configurations.rst
@@ -33,8 +33,8 @@ possible using SQLAlchemy:
 ::
 
     from flask import Flask, current_app, render_template
-    from flask.ext.sqlalchemy import SQLAlchemy
-    from flask.ext.security import Security, SQLAlchemyUserDatastore, \
+    from flask_sqlalchemy import SQLAlchemy
+    from flask_security import Security, SQLAlchemyUserDatastore, \
         UserMixin, RoleMixin, login_required
 
 
@@ -101,7 +101,7 @@ possible using SQLAlchemy:
         db.create_all()
         user_datastore.create_user(email='gal@lp.com', password='password', username='gal',
                                tf_totp_secret=None, tf_primary_method=None)
-        db.session.commit()
+        db.commit()
 
     # Views
     @app.route('/')

--- a/examples/fsqlalchemy1.py
+++ b/examples/fsqlalchemy1.py
@@ -30,6 +30,12 @@ app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 # Bcrypt is set as default SECURITY_PASSWORD_HASH, which requires a salt
 app.config["SECURITY_PASSWORD_SALT"] = "super-secret-random-salt"
 
+# As of Flask-SQLAlchemy 2.4.0 it is easy to pass in options directly to the
+# underlying engine. This option makes sure that DB connections from the pool
+# are still valid. Important for entire application since many DBaaS options
+# automatically close idle connections.
+app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {"pool_pre_ping": True}
+
 app.json_encoder = JSONEncoder
 
 # Create database connection object

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -10,8 +10,11 @@
     :license: MIT, see LICENSE for more details.
 """
 
+# flake8: noqa: F401
+
 from .core import Security, RoleMixin, UserMixin, AnonymousUser, current_user
 from .datastore import (
+    UserDatastore,
     SQLAlchemyUserDatastore,
     MongoEngineUserDatastore,
     PeeweeUserDatastore,
@@ -31,23 +34,49 @@ from .decorators import (
     unauth_csrf,
 )
 from .forms import (
+    ChangePasswordForm,
     ForgotPasswordForm,
     LoginForm,
     RegisterForm,
     ResetPasswordForm,
     PasswordlessLoginForm,
     ConfirmRegisterForm,
+    SendConfirmationForm,
+    TwoFactorRescueForm,
+    TwoFactorSetupForm,
+    TwoFactorVerifyCodeForm,
+    TwoFactorVerifyPasswordForm,
 )
 from .signals import (
     confirm_instructions_sent,
+    login_instructions_sent,
+    password_changed,
     password_reset,
     reset_password_instructions_sent,
+    tf_code_confirmed,
+    tf_profile_changed,
+    tf_security_token_sent,
+    tf_disabled,
     user_confirmed,
     user_registered,
 )
-from .utils import login_user, logout_user, url_for_security
+from .utils import (
+    SmsSenderBaseClass,
+    SmsSenderFactory,
+    get_hmac,
+    get_token_status,
+    get_url,
+    hash_password,
+    login_user,
+    logout_user,
+    send_mail,
+    transform_url,
+    url_for_security,
+    verify_password,
+    verify_and_update_password,
+)
 
-__version__ = "3.3.0rc1"
+__version__ = "3.3.0rc2"
 __all__ = (
     "AnonymousUser",
     "ConfirmRegisterForm",

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -787,7 +787,8 @@ class Security(object):
             # various config checks - some of these are opinionated in that there
             # could be a reason for some of these combinations - but in general
             # they cause strange behavior.
-            if not current_app.config["WTF_CSRF_ENABLED"]:
+            # WTF_CSRF_ENABLED defaults to True if not set in Flask-WTF
+            if not current_app.config.get("WTF_CSRF_ENABLED", True):
                 return
             csrf = current_app.extensions.get("csrf", None)
 
@@ -800,7 +801,7 @@ class Security(object):
                         "CSRF_PROTECT_MECHANISMS defined but"
                         " CsrfProtect not part of application"
                     )
-                if current_app.config["WTF_CSRF_CHECK_DEFAULT"]:
+                if current_app.config.get("WTF_CSRF_CHECK_DEFAULT", True):
                     raise ValueError(
                         "WTF_CSRF_CHECK_DEFAULT must be set to False if"
                         " CSRF_PROTECT_MECHANISMS is set"
@@ -810,7 +811,7 @@ class Security(object):
             if (
                 cv("CSRF_IGNORE_UNAUTH_ENDPOINTS")
                 and csrf
-                and current_app.config["WTF_CSRF_CHECK_DEFAULT"]
+                and current_app.config.get("WTF_CSRF_CHECK_DEFAULT", False)
             ):
                 raise ValueError(
                     "To ignore unauth endpoints you must set WTF_CSRF_CHECK_DEFAULT"
@@ -901,7 +902,7 @@ class Security(object):
 
         :param payload: A dict. Please see the formal API spec for details.
         :param code: Http status code
-        :param user: the UserDatastore object (or None). Not that this is usually
+        :param user: the UserDatastore object (or None). Note that this is usually
                        the same as current_user - but not always.
 
         The default implementation simply returns::

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -314,6 +314,8 @@ def transform_url(url, qparams=None, **kwargs):
     :param qparams: additional query params to add to end of url
     :param kwargs: pieces of URL to modify - e.g. netloc=localhost:8000
     :return: Modified URL
+
+    .. versionadded:: 3.2.0
     """
     if not url:
         return url
@@ -678,7 +680,10 @@ class SmsSenderBaseClass(object):
 
     @abc.abstractmethod
     def send_sms(self, from_number, to_number, msg):  # pragma: no cover
-        """ Abstract method for sending sms messages """
+        """ Abstract method for sending sms messages
+
+        .. versionadded:: 3.2.0
+        """
         return
 
 
@@ -696,6 +701,8 @@ class SmsSenderFactory(object):
         """ Initialize an SMS sender.
 
         :param name: Name as registered in SmsSenderFactory:senders (e.g. 'Twilio')
+
+        .. versionadded:: 3.2.0
         """
         return cls.senders[name](*args, **kwargs)
 


### PR DESCRIPTION
Make sure that public/documented API is all available from the flask_security namespace
and doesn't require nor document the model layout of the source.

Fixed some bugs in CSRF option checking.

Added example of setting 'pool_pre_ping' in SQLAlchemy examples - since this is really
important for production.

Updated CHANGES

Bump version to 3.3.0rc2