### PR TITLE
fix/feature - Improve unauthenticated/unauthorized handlers.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ Released TBD
   token based authentication. Add extensive documentation about all the options.
 - (:issue:`130`) Enable applications to provide their own :meth:`.render_json` method so that they can create
   unified API responses.
+- (:issue:`121`) Unauthorization callback not quite right. Split into 2 different callbacks - one for
+  unauthorized and one for unauthenticated. Made default unauthenticated handler use Flask-Login's unauthenticated
+  method to make everything uniform. Extensive documentation added. :meth:`.Security.unauthorized_callback` has been deprecated.
 - Improve documentation for :meth:`.UserDatastore.create_user` to make clear that hashed password
   should be passed in.
 - Improve documentation for :class:`.UserDatastore` and :func:`.verify_and_update_password`
@@ -35,6 +38,12 @@ Possible compatibility issues:
   has a property ``permissions`` and assumes it is a comma separated string of permissions.
   If your model already has such a property this will likely fail. You need to override ``get_permissions``
   and simply return an emtpy set. (jwag956)
+
+- (:issue:`121`) Changes the default (failure) behavior for views protected with @auth_required, @token_auth_required,
+  or @http_auth_required. Before, a 401 was returned with some stock html. Now, Flask-Login.unauthorized() is
+  called (the same as @login_required does) - which by default redirects to a login page/view. If you had provided your own
+  :meth:`.Security.unauthorized_callback` there are no changes - that will still be called first. The old default
+  behavior can be restored by setting ``BACKWARDS_COMPAT_UNAUTH`` to True.
 
 Version 3.2.0
 -------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,10 +15,6 @@ Core
 
    A proxy for the current user.
 
-.. function:: flask_security.Security.render_json_func
-
-    A decorator for :meth:`.Security.render_json`
-
 .. function:: flask_security.Security.unauthorized_handler
 
     If an endpoint fails authentication or authorization from one of the decorators
@@ -26,6 +22,8 @@ Core
     (except ``login_required``), a method annotated with this decorator will be called.
     For ``login_required`` (which is implemented in Flask-Login) use
     **flask_security.login_manager.unauthorized_handler**
+
+    ..deprecated:: 3.3.0
 
 Protecting Views
 ----------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -469,6 +469,9 @@ Miscellaneous
 ``SECURITY_DATETIME_FACTORY``                 Specifies the default datetime
                                               factory. Defaults to
                                               ``datetime.datetime.utcnow``.
+``SECURITY_BACKWARDS_COMPAT_UNAUTHN``         If set to ``True`` then the default behavior for authentication
+                                              failures from one of Flask-Security's decorators will be restored to
+                                              be compatibile with prior releases (return 401 and some static html)
 ============================================= ==================================
 
 Messages

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -263,6 +263,45 @@ For example, you might want to use an alternative email library like `Flask-Emai
     The above ``security.send_mail_task`` override will be useless if you
     override the entire ``send_mail`` method.
 
+Responses
+---------
+Flask-Security will likely be a very small piece of your application,
+so Flask-Security makes it easy to override all aspects of API responses.
+
+JSON Response
++++++++++++++
+Applications that support a JSON based API need to be able to have a uniform
+API response. Flask-Security has a default way to render its API responses - which can
+be easily overridden by either providing a callback function via :meth:`.Security.render_json`.
+
+401, 403, Oh My
++++++++++++++++
+For a very long read and discussion look at `this`_. Out of the box, Flask-Security in
+tandem with Flask-Login, behaves as follows:
+
+    * If authentication fails as the result of a @login_required, @auth_required,
+      @http_auth_required, or @token_auth_required then if the request 'wants' a JSON
+      response, :meth:`.Security.render_json` is called with a 401 status code. If not
+      then flask_login.LoginManager.unauthorized() is called. By default THAT will redirect to
+      a login view.
+
+    * If authorization fails as the result of @roles_required, @roles_accepted,
+      @permissions_required, or @permissions_accepted, then if the request 'wants' a JSON
+      response, :meth:`.Security.render_json` is called with a 403 status code. If not,
+      then if ``SECURITY_UNAUTHORIZED_VIEW`` is defined, the response will redirected.
+      If ``SECURITY_UNAUTHORIZED_VIEW`` is not defined, then ``abort(403)`` is called.
+
+All this can be easily changed by defining any or all of :meth:`.Security.render_json`,
+:meth:`.Security.unauthn_handler` and :meth:`.Security.unauthz_handler`.
+
+The decision on whether to return JSON is based on:
+
+    * Was the request content-type "application/json" (e.g. request.is_json()) OR
+
+    * Is the 'best' value of the ``Accept`` HTTP header "application/json"
+
+
+.. _`this`: https://stackoverflow.com/questions/3297048/403-forbidden-vs-401-unauthorized-http-responses
 
 Authorization with OAuth2
 -------------------------

--- a/docs/spa.rst
+++ b/docs/spa.rst
@@ -2,9 +2,9 @@ Working with Single Page Applications
 ======================================
 `Single Page Applications (spa)`_ are a popular model for both separating
 user interface from application/backend code as well as providing a responsive
-user experience. Angular and Vue are popular Javescript frameworks for writing SPAs.
+user experience. Angular and Vue are popular Javascript frameworks for writing SPAs.
 An added benefit is that the UI can be developed completely independently (in a separate repo)
-and take advantage of the latest Javescript packing and bundling techonologies that are
+and take advantage of the latest Javascript packing and bundling technologies that are
 evolving rapidly, and not make the Flask application have to deal with things
 like Flask-Webpack or webassets.
 
@@ -69,8 +69,7 @@ An example configuration::
     security = Security(app, user_datastore)
 
     # Optionally define and set unauthorized callbacks
-    security.login_manager.unauthorized_handler(unauth)
-    security.unauthorized_handler(unauth)
+    security.unauthz_handler(<your unauth handler>)
 
 When in development mode, the Flask application will run by default on port 5000.
 The UI might want to run on port 8080. In order to test redirects you need to set::

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -38,7 +38,7 @@ _security = LocalProxy(lambda: current_app.extensions["security"])
 _csrf = LocalProxy(lambda: current_app.extensions["csrf"])
 
 
-_default_unauthorized_html = """
+_default_unauthenticated_html = """
     <h1>Unauthorized</h1>
     <p>The server could not verify that you are authorized to access the URL
     requested. You either supplied the wrong credentials (e.g. a bad password),
@@ -49,13 +49,31 @@ _default_unauthorized_html = """
 BasicAuth = namedtuple("BasicAuth", "username, password")
 
 
-def _get_unauthorized_response(text=None, headers=None):
-    text = text or _default_unauthorized_html
+def _get_unauthenticated_response(text=None, headers=None):
+    text = text or _default_unauthenticated_html
     headers = headers or {}
     return Response(text, 401, headers)
 
 
-def _get_unauthorized_view():
+def default_unauthn_handler(mechanisms, headers=None):
+    """ Default callback for failures to authenticate
+
+    If caller wants JSON - return 401
+    Otherwise - assume caller is html and redirect if possible to a login view.
+    We let Flask-Login handle this.
+
+    """
+    if utils.config_value("BACKWARDS_COMPAT_UNAUTHN"):
+        return _get_unauthenticated_response(headers=headers)
+    if _security._want_json(request):
+        # TODO can/should we response with a WWW-Authenticate Header in all cases?
+        return _security._render_json({}, 401, headers, None)
+    return _security.login_manager.unauthorized()
+
+
+def default_unauthz_handler(func, params):
+    if _security._want_json(request):
+        return _security._render_json({}, 403, None, None)
     view = utils.config_value("UNAUTHORIZED_VIEW")
     if view:
         if callable(view):
@@ -161,7 +179,7 @@ def http_auth_required(realm):
             else:
                 r = _security.default_http_auth_realm if callable(realm) else realm
                 h = {"WWW-Authenticate": 'Basic realm="%s"' % r}
-                return _get_unauthorized_response(headers=h)
+                return _security._unauthn_handler(["basic"], headers=h)
 
         return wrapper
 
@@ -188,7 +206,7 @@ def auth_token_required(fn):
         if _security._unauthorized_callback:
             return _security._unauthorized_callback()
         else:
-            return _get_unauthorized_response()
+            return _security._unauthn_handler(["token"])
 
     return decorated
 
@@ -224,7 +242,9 @@ def auth_required(*auth_methods):
     }
     mechanisms_order = ["token", "session", "basic"]
     if not auth_methods:
-        auth_methods = ("basic", "session", "token")
+        auth_methods = {"basic", "session", "token"}
+    else:
+        auth_methods = [am for am in auth_methods]
 
     def wrapper(fn):
         @wraps(fn)
@@ -245,7 +265,7 @@ def auth_required(*auth_methods):
             if _security._unauthorized_callback:
                 return _security._unauthorized_callback()
             else:
-                return _get_unauthorized_response(headers=h)
+                return _security._unauthn_handler(auth_methods, headers=h)
 
         return decorated_view
 
@@ -329,9 +349,9 @@ def roles_required(*roles):
             for perm in perms:
                 if not perm.can():
                     if _security._unauthorized_callback:
+                        # Backwards compat - deprecated
                         return _security._unauthorized_callback()
-                    else:
-                        return _get_unauthorized_view()
+                    return _security._unauthz_handler(roles_required, list(roles))
             return fn(*args, **kwargs)
 
         return decorated_view
@@ -361,9 +381,9 @@ def roles_accepted(*roles):
             if perm.can():
                 return fn(*args, **kwargs)
             if _security._unauthorized_callback:
+                # Backwards compat - deprecated
                 return _security._unauthorized_callback()
-            else:
-                return _get_unauthorized_view()
+            return _security._unauthz_handler(roles_accepted, list(roles))
 
         return decorated_view
 
@@ -396,9 +416,12 @@ def permissions_required(*fsperms):
             for perm in perms:
                 if not perm.can():
                     if _security._unauthorized_callback:
+                        # Backwards compat - deprecated
                         return _security._unauthorized_callback()
-                    else:
-                        return _get_unauthorized_view()
+                    return _security._unauthz_handler(
+                        permissions_required, list(fsperms)
+                    )
+
             return fn(*args, **kwargs)
 
         return decorated_view
@@ -432,9 +455,9 @@ def permissions_accepted(*fsperms):
             if perm.can():
                 return fn(*args, **kwargs)
             if _security._unauthorized_callback:
+                # Backwards compat - deprecated
                 return _security._unauthorized_callback()
-            else:
-                return _get_unauthorized_view()
+            return _security._unauthz_handler(permissions_accepted, list(fsperms))
 
         return decorated_view
 

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -601,6 +601,20 @@ def csrf_cookie_handler(response):
     return response
 
 
+def default_want_json(req):
+    """ Return True if response should be in json
+    N.B. do not call this directly - use security.want_json()
+
+    :param req: Flask/Werkzeug Request
+    """
+    if req.is_json:
+        return True
+    # TODO should this handle json sub-types?
+    if req.accept_mimetypes.best == "application/json":
+        return True
+    return False
+
+
 @contextmanager
 def capture_passwordless_login_requests():
     login_requests = []

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -136,13 +136,13 @@ def _base_render_json(
         if additional:
             payload.update(additional)
 
-    return _security._render_json(payload, code, user)
+    return _security._render_json(payload, code, headers=None, user=user)
 
 
-def default_render_json(payload, code, user):
+def default_render_json(payload, code, headers, user):
     """ Default JSON response handler.
     """
-    return jsonify(dict(meta=dict(code=code), response=payload)), code
+    return jsonify(dict(meta=dict(code=code), response=payload)), code, headers
 
 
 def _commit(response=None):
@@ -233,7 +233,7 @@ def logout():
 
     # No body is required - so if a POST and json - return OK
     if request.method == "POST" and request.is_json:
-        return jsonify(dict(meta=dict(code=200)))
+        return _security._render_json({}, 200, headers=None, user=None)
 
     return redirect(get_post_logout_redirect())
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -xrs --cov flask_security --cov-report term-missing --black --flake8 --cache-clear
+addopts = -rs --cov flask_security --cov-report term-missing --black --flake8 --cache-clear
 flake8-max-line-length = 88
 flake8-ignore =
     tests/view_scaffold.py E402

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -286,13 +286,15 @@ def test_token_auth_via_header_valid_token(client):
 
 
 def test_token_auth_via_querystring_invalid_token(client):
-    response = client.get("/token?auth_token=X")
-    assert 401 == response.status_code
+    response = client.get("/token?auth_token=X", headers={"Accept": "application/json"})
+    assert response.status_code == 401
 
 
 def test_token_auth_via_header_invalid_token(client):
-    response = client.get("/token", headers={"Authentication-Token": "X"})
-    assert 401 == response.status_code
+    response = client.get(
+        "/token", headers={"Authentication-Token": "X", "Accept": "application/json"}
+    )
+    assert response.status_code == 401
 
 
 def test_http_auth(client):
@@ -318,6 +320,7 @@ def test_http_auth_username(client):
     assert b"HTTP Authentication" in response.data
 
 
+@pytest.mark.settings(backwards_compat_unauthn=True)
 def test_http_auth_no_authorization(client):
     response = client.get("/http", headers={})
     assert b"<h1>Unauthorized</h1>" in response.data
@@ -325,6 +328,7 @@ def test_http_auth_no_authorization(client):
     assert 'Basic realm="Login Required"' == response.headers["WWW-Authenticate"]
 
 
+@pytest.mark.settings(backwards_compat_unauthn=True)
 def test_invalid_http_auth_invalid_username(client):
     response = client.get(
         "/http",
@@ -338,6 +342,7 @@ def test_invalid_http_auth_invalid_username(client):
     assert 'Basic realm="Login Required"' == response.headers["WWW-Authenticate"]
 
 
+@pytest.mark.settings(backwards_compat_unauthn=True)
 def test_invalid_http_auth_bad_password(client):
     response = client.get(
         "/http",
@@ -351,6 +356,7 @@ def test_invalid_http_auth_bad_password(client):
     assert 'Basic realm="Login Required"' == response.headers["WWW-Authenticate"]
 
 
+@pytest.mark.settings(backwards_compat_unauthn=True)
 def test_custom_http_auth_realm(client):
     response = client.get(
         "/http_custom_realm",
@@ -375,9 +381,11 @@ def test_multi_auth_basic(client):
     assert b"Basic" in response.data
 
     response = client.get("/multi_auth")
-    assert response.status_code == 401
+    # Default unauthn is to redirect
+    assert response.status_code == 302
 
 
+@pytest.mark.settings(backwards_compat_unauthn=True)
 def test_multi_auth_basic_invalid(client):
     response = client.get(
         "/multi_auth",

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -35,9 +35,8 @@ def test_view_configuration(client):
         "/http",
         headers={"Authorization": "Basic %s" % base64.b64encode(b"joe@lp.com:bogus")},
     )
-    assert b"<h1>Unauthorized</h1>" in response.data
-    assert "WWW-Authenticate" in response.headers
-    assert 'Basic realm="Custom Realm"' == response.headers["WWW-Authenticate"]
+    assert response.status_code == 302
+    assert response.headers["Location"] == "http://localhost/custom_login?next=%2Fhttp"
 
 
 @pytest.mark.settings(login_user_template="custom_security/login_user.html")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -9,7 +9,6 @@
 import hashlib
 
 import pytest
-from flask import jsonify
 
 from utils import authenticate, check_xlation, init_app_with_options, populate_data
 
@@ -442,28 +441,3 @@ def test_per_request_xlate(app, client):
     assert response.jdata["response"]["errors"]["new_password"] == [
         "Merci d'indiquer un mot de passe"
     ]
-
-
-def test_render_json(app, client):
-    @app.security.render_json_func
-    def my_json(payload, code, user):
-        return jsonify(dict(myresponse=payload, code=code))
-
-    response = client.get(
-        "/login", data={}, headers={"Content-Type": "application/json"}
-    )
-    assert "myresponse" in response.jdata
-    assert response.jdata["code"] == 200
-
-
-def _my_json(payload, code, user):
-    return jsonify(dict(myresponse=payload, code=code))
-
-
-@pytest.mark.settings(render_json=_my_json)
-def test_render_json2(app, client):
-    response = client.get(
-        "/login", data={}, headers={"Content-Type": "application/json"}
-    )
-    assert "myresponse" in response.jdata
-    assert response.jdata["code"] == 200

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+"""
+    test_respnse
+    ~~~~~~~~~~~~~~~~~
+
+    Tests for validating default and plugable responses.
+
+    :copyright: (c) 2019 by J. Christopher Wagner (jwag).
+    :license: MIT, see LICENSE for more details.
+"""
+
+import pytest
+
+from flask import jsonify
+
+from utils import authenticate
+
+
+def test_render_json(app, client):
+    @app.security.render_json
+    def my_json(payload, code, headers=None, user=None):
+        return jsonify(dict(myresponse=payload, code=code))
+
+    response = client.get(
+        "/login", data={}, headers={"Content-Type": "application/json"}
+    )
+    assert "myresponse" in response.jdata
+    assert response.jdata["code"] == 200
+
+
+def _my_json(payload, code, headers=None, user=None):
+    return jsonify(dict(myresponse=payload, code=code))
+
+
+def test_render_json2(app, client):
+    app.extensions["security"].render_json(_my_json)
+    response = client.get(
+        "/login", data={}, headers={"Content-Type": "application/json"}
+    )
+    assert "myresponse" in response.jdata
+    assert response.jdata["code"] == 200
+
+
+def test_render_json_logout(app, client):
+    app.extensions["security"].render_json(_my_json)
+    response = client.post("/logout", headers={"Content-Type": "application/json"})
+    assert "myresponse" in response.jdata
+    assert response.jdata["code"] == 200
+
+
+def test_default_unauthn(app, client):
+    """ Test default unauthn handler with and without json """
+
+    response = client.get("/multi_auth")
+    assert response.status_code == 302
+    assert response.headers["Location"] == "http://localhost/login?next=%2Fmulti_auth"
+
+    response = client.get("/multi_auth", headers={"Accept": "application/json"})
+    assert response.status_code == 401
+    assert response.jdata["meta"]["code"] == 401
+    # Since "basic" is acceptible - we should get a WWW-Authenticate header back
+    assert "WWW-Authenticate" in response.headers
+
+
+@pytest.mark.settings(login_url="/mylogin", url_prefix="/myprefix")
+def test_default_unauthn_bp(app, client):
+    """ Test default unauthn handler with blueprint prefix and login url """
+
+    response = client.get("/multi_auth")
+    assert response.status_code == 302
+    assert (
+        response.headers["Location"]
+        == "http://localhost/myprefix/mylogin?next=%2Fmulti_auth"
+    )
+
+
+def test_default_unauthn_myjson(app, client):
+    """ Make sure render_json gets called for unauthn errors """
+
+    @app.security.render_json
+    def my_json(payload, code, headers=None, user=None):
+        return jsonify(dict(myresponse=payload, code=code)), code, headers
+
+    response = client.get("/multi_auth", headers={"Accept": "application/json"})
+    assert response.status_code == 401
+    assert response.jdata["code"] == 401
+    assert "myresponse" in response.jdata
+
+
+def test_my_unauthn_handler(app, client):
+    @app.security.unauthn_handler
+    def my_unauthn(mechanisms, headers=None):
+        return app.security._render_json({"mechanisms": mechanisms}, 401, headers, None)
+
+    response = client.get("/multi_auth", headers={"Accept": "application/json"})
+    assert response.status_code == 401
+    assert all(
+        m in response.jdata["response"]["mechanisms"]
+        for m in ["session", "token", "basic"]
+    )
+
+
+def test_default_unauthz(app, client):
+    """ Test default unauthz handler with and without json """
+    authenticate(client, "joe@lp.com", "password")
+
+    response = client.get("/admin")
+    # This is the result of abort(403) since there is no UNAUTHORIZED_VIEW
+    assert response.status_code == 403
+
+    response = client.get("/admin", headers={"Accept": "application/json"})
+    assert response.status_code == 403
+    assert response.jdata["meta"]["code"] == 403
+
+
+def test_default_unauthz_myjson(app, client):
+    """ Make sure render_json gets called for unauthn errors """
+
+    @app.security.render_json
+    def my_json(payload, code, headers=None, user=None):
+        return jsonify(dict(myresponse=payload, code=code)), code, headers
+
+    authenticate(client, "joe@lp.com", "password")
+
+    response = client.get("/admin", headers={"Accept": "application/json"})
+    assert response.status_code == 403
+    assert response.jdata["code"] == 403
+
+
+def test_my_unauthz_handler(app, client):
+    @app.security.unauthz_handler
+    def my_unauthz(func, params):
+        return (
+            jsonify(
+                dict(myresponse={"func": func.__name__, "params": params}, code=403)
+            ),
+            403,
+        )
+
+    authenticate(client, "joe@lp.com", "password")
+
+    response = client.get("/admin", headers={"Accept": "application/json"})
+    assert response.status_code == 403
+    assert response.jdata["code"] == 403
+    assert response.jdata["myresponse"]["func"] == "roles_required"
+    assert response.jdata["myresponse"]["params"] == ["admin"]
+
+
+def test_my_unauthz_handler_exc(app, client):
+    """ Verify that can use exceptions in unauthz handler """
+
+    @app.security.unauthz_handler
+    def my_unauthz(func, params):
+        raise ValueError("Bad Value")
+
+    @app.errorhandler(ValueError)
+    def error_handler(ex):
+        return jsonify(dict(code=403)), 403
+
+    authenticate(client, "joe@lp.com", "password")
+
+    response = client.get("/admin", headers={"Accept": "application/json"})
+    assert response.status_code == 403


### PR DESCRIPTION
Prior to this, FS had a single unauthorized_handler that was called for both
authentication failures as well as authorization failures. The default
authentication handler simply returned 401 and a static html string. The default
unauthorized handler either redirected to UNAUTHORIZED_VIEW or did an abort(403)

This made FS authentication decorator behavior different than @login_required,
and made it difficult to have a handler for JSON that could differentiate between the 2.

2 new handlers - unauthn_handler and unauthz_handler were added.
unauthorized_handler has been deprecated.
Furthermore, both default handlers look to see if the response should be JSON and calls
render_json - this gives a nice easy hook for applications to have uniform API error responses.

Furthermore, the default unauthn_handler now simply calls login_manager.unauthorized() so
all authentication error handling is uniform.

Added docs, examples, etc.

Fixed bug in POST /logout where render_json wasn't being called.