### PR TITLE
fix - better fix for handling LazyStrings when serializing JSON.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,6 @@
 Flask-Security was written by Matt Wright and various contributors.
 
-Flask-Security-Too is a fork:
+Flask-Security-Too is an independently maintained repo:
 
 Development Lead
 ````````````````

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,13 +37,19 @@ Possible compatibility issues:
   each request to add Permissions to the authenticated user. It checks if the RoleModel
   has a property ``permissions`` and assumes it is a comma separated string of permissions.
   If your model already has such a property this will likely fail. You need to override ``get_permissions``
-  and simply return an emtpy set. (jwag956)
+  and simply return an emtpy set.
 
 - (:issue:`121`) Changes the default (failure) behavior for views protected with @auth_required, @token_auth_required,
   or @http_auth_required. Before, a 401 was returned with some stock html. Now, Flask-Login.unauthorized() is
   called (the same as @login_required does) - which by default redirects to a login page/view. If you had provided your own
   :meth:`.Security.unauthorized_callback` there are no changes - that will still be called first. The old default
   behavior can be restored by setting ``BACKWARDS_COMPAT_UNAUTH`` to True.
+
+- (:issue:`127`) Fix for LazyStrings in json error response. The fix for this has Flask-Security registering
+  its own JsonEncoder on its blueprint. If you registered your own JsonEncoder for your app - it will no
+  longer be called when serializing responses to Flask-Security endpoints. You can register your JsonEncoder
+  on Flask-Security's blueprint by sending it as `json_encoder_cls` as part of initialization. Be aware that your
+  JsonEncoder needs to handle LazyStrings (see speaklater).
 
 Version 3.2.0
 -------------

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (C) 2012-2019 by Matthew Wright
+Copyright (C) 2019-2019 by Chris Wagner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,8 @@ Quickly add security features to your Flask application.
 
 Notes on this repo
 ------------------
-This is a fork of mattupstate/flask-security starting with 3.0.0 master branch.
+This is a independently maintained version of Flask-Security based on the 3.0.0
+version of the `Original <https://github.com/mattupstate/flask-security>`_
 
 Goals
 +++++
@@ -42,12 +43,14 @@ Goals
 * Migrate to more modern paradigms such as using oauth2 and JWT for token acquisition.
 * Be more opinionated and 'batteries' included by reducing reliance on abandoned projects and
   bundling in support for common use cases.
+* Follow the `Pallets <https://github.com/pallets>`_ lead on supported versions, documentation
+  standards and any other guidelines for extentions that they come up with.
 * Any other great ideas.
 
 Contributing
 ++++++++++++
 Issues and pull requests are welcome. Other maintainers are also welcome. Unlike
-the upstream Flask-Security - issue pull requests against the *master* branch.
+the original Flask-Security - issue pull requests against the *master* branch.
 
 
 Resources

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -23,7 +23,7 @@ Core
     For ``login_required`` (which is implemented in Flask-Login) use
     **flask_security.login_manager.unauthorized_handler**
 
-    ..deprecated:: 3.3.0
+    .. deprecated:: 3.3.0
 
 Protecting Views
 ----------------
@@ -107,6 +107,8 @@ Utils
 .. autofunction:: flask_security.get_url
 
 .. autofunction:: flask_security.transform_url
+
+.. autoclass:: flask_security.FsJsonEncoder
 
 .. autoclass:: flask_security.SmsSenderBaseClass
   :members: send_sms

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -273,10 +273,12 @@ JSON Response
 Applications that support a JSON based API need to be able to have a uniform
 API response. Flask-Security has a default way to render its API responses - which can
 be easily overridden by either providing a callback function via :meth:`.Security.render_json`.
+As documents in :meth:`Security.render_json`, be aware that Flask-Security registers
+its own JsonEncoder on its blueprint.
 
 401, 403, Oh My
 +++++++++++++++
-For a very long read and discussion look at `this`_. Out of the box, Flask-Security in
+For a very long read and discussion; look at `this`_. Out of the box, Flask-Security in
 tandem with Flask-Login, behaves as follows:
 
     * If authentication fails as the result of a @login_required, @auth_required,

--- a/docs/spa.rst
+++ b/docs/spa.rst
@@ -85,7 +85,18 @@ standard security headers such as:
     * ``Strict-Transport-Security``
     * ``X-Frame-Options``
     * ``Content Security Policy``
+    * ``X-Content-Type-Options``
+    * ``X-XSS-Protection``
+    * ``Referrer policy``
 
+Some background material:
+
+    * Specific to `S3`_ but easily adaptable
+
+    * `Flask-Talisman`_ - useful if serving everything from your Flask application - also
+      useful as a good list of things to consider.
 
 .. _Single Page Applications (spa): https://en.wikipedia.org/wiki/Single-page_application
 .. _Nginx: https://www.nginx.com/
+.. _S3: https://www.savjee.be/2018/05/Content-security-policy-and-aws-s3-cloudfront/
+.. _Flask-Talisman: https://github.com/GoogleCloudPlatform/flask-talisman

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -61,6 +61,7 @@ from .signals import (
     user_registered,
 )
 from .utils import (
+    FsJsonEncoder,
     SmsSenderBaseClass,
     SmsSenderFactory,
     get_hmac,
@@ -76,7 +77,7 @@ from .utils import (
     verify_and_update_password,
 )
 
-__version__ = "3.3.0rc2"
+__version__ = "3.3.0rc3"
 __all__ = (
     "AnonymousUser",
     "ConfirmRegisterForm",

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -266,11 +266,14 @@ class UserDatastore(object):
         """Creates and returns a new user from the given parameters.
 
         :kwparam email: required.
-        :kwparam password:  Hashed password. Be aware that whatever is passed in will
-            be stored directly in the DB. Do NOT pass in a plaintext password!
-            Best practice is to pass in hash_password(plaintext_password).
+        :kwparam password:  Hashed password.
         :kwparam roles: list of roles to be added to user.
             Can be Role objects or strings
+
+        .. danger::
+           Be aware that whatever `password` is passed in will
+           be stored directly in the DB. Do NOT pass in a plaintext password!
+           Best practice is to pass in ``hash_password(plaintext_password)``.
 
         The new user's ``active`` property will be set to true.
         """

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -133,13 +133,13 @@ def handle_csrf(method):
 
     This routine does nothing if any of these are true:
 
-        #) ``WTF_CSRF_ENABLED`` is set to False
+        #) `WTF_CSRF_ENABLED` is set to False
 
         #) the Flask-WTF CSRF module hasn't been initialized
 
         #) csrfProtect already checked and accepted the token
 
-    If the passed in method is not in ``CSRF_PROTECT_MECHANISMS`` then not only
+    If the passed in method is not in `CSRF_PROTECT_MECHANISMS` then not only
     will no CSRF code be run, but a flag in the current context ``fs_ignore_csrf``
     will be set so that downstream code knows to ignore any CSRF checks.
 
@@ -275,19 +275,19 @@ def auth_required(*auth_methods):
 def unauth_csrf(fall_through=False):
     """Decorator for endpoints that don't need authentication
     but do want CSRF checks (available via Header rather than just form).
-    This is required when setting WTF_CSRF_CHECK_DEFAULT=False since in that
+    This is required when setting `WTF_CSRF_CHECK_DEFAULT` = False since in that
     case, without this decorator, the form validation will attempt to do the CSRF
     check, and that will fail since the csrf-token is in the header (for pure JSON
     requests).
 
     This decorator does nothing unless Flask-WTF::CSRFProtect has been initialized.
 
-    This decorator does nothing if WTF_CSRF_ENABLED==False.
+    This decorator does nothing if `WTF_CSRF_ENABLED` == False.
 
     This decorator will always require CSRF if the caller is authenticated.
 
     This decorator will suppress CSRF if caller isn't authenticated and has set the
-    "CSRF_IGNORE_UNAUTH_ENDPOINTS" config variable.
+    `CSRF_IGNORE_UNAUTH_ENDPOINTS` config variable.
 
     :param fall_through: if set to True, then if CSRF fails here - simply keep going.
         This is appropriate if underlying view is form based and once the form is


### PR DESCRIPTION
Attach our own JsonEncoder to our blueprint which knows how to handle
LazyString.
Applications can set their own using 'json_encoder_cls' as part of initialization.

The default encoder - FsJsonEncoder is a public function.

Fix and improve docs - more links, etc.

Change docs to reflect that this is no longer a fork.