### PR TITLE
chore - put back _get_unauthorized_response

### DIFF
--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -55,6 +55,11 @@ def _get_unauthenticated_response(text=None, headers=None):
     return Response(text, 401, headers)
 
 
+def _get_unauthorized_response(text=None, headers=None):  # pragma: no cover
+    # People called this - even though it isn't public - no harm in keeping it.
+    return _get_unauthenticated_response(text, headers)
+
+
 def default_unauthn_handler(mechanisms, headers=None):
     """ Default callback for failures to authenticate
 


### PR DESCRIPTION
So far 2 folks have said they call it - no harm in having it - but
it still isn't public.