### PR TITLE
fix - role.permissions == None threw exception

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -508,7 +508,7 @@ class RoleMixin(object):
 
         .. versionadded:: 3.3.0
         """
-        if hasattr(self, "permissions"):
+        if hasattr(self, "permissions") and self.permissions:
             # These are a comma separated list
             return set(self.permissions.split(","))
         return set([])
@@ -524,7 +524,7 @@ class RoleMixin(object):
         .. versionadded:: 3.3.0
         """
         if hasattr(self, "permissions"):
-            current_perms = set(self.permissions.split(","))
+            current_perms = self.get_permissions()
             if isinstance(permissions, set):
                 perms = permissions
             elif isinstance(permissions, list):
@@ -546,7 +546,7 @@ class RoleMixin(object):
         .. versionadded:: 3.3.0
         """
         if hasattr(self, "permissions"):
-            current_perms = set(self.permissions.split(","))
+            current_perms = self.get_permissions()
             if isinstance(permissions, set):
                 perms = permissions
             elif isinstance(permissions, list):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,6 +159,11 @@ def app(request):
     def admin_or_editor():
         return render_template("index.html", content="Admin or Editor Page")
 
+    @app.route("/simple")
+    @roles_accepted("simple")
+    def simple():
+        return render_template("index.html", content="SimplePage")
+
     @app.route("/admin_perm")
     @permissions_accepted("full-write", "super")
     def admin_perm():

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -4,6 +4,10 @@
     ~~~~~~~~~~~~~~
 
     Datastore tests
+
+    :copyright: (c) 2012 by Matt Wright.
+    :copyright: (c) 2019 by J. Christopher Wagner (jwag).
+    :license: MIT, see LICENSE for more details.
 """
 
 import datetime
@@ -283,6 +287,18 @@ def test_modify_permissions(app, datastore):
         t1 = ds.find_role("test1")
         assert {"write", "execute"} == t1.get_permissions()
         assert t1.update_datetime > orig_update_time
+
+
+def test_get_permissions(app, datastore):
+    """ Verify that role.permissions = None works. """
+    ds = datastore
+    if not hasattr(ds.role_model, "permissions"):
+        return
+    init_app_with_options(app, ds)
+
+    with app.app_context():
+        t1 = ds.find_role("simple")
+        assert set() == t1.get_permissions()
 
 
 def test_modify_permissions_multi(app, datastore):

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -293,11 +293,12 @@ def test_reset_token_deleted_user(app, client, get_message, sqlalchemy_datastore
     with capture_reset_password_requests() as requests:
         client.post("/reset", data=dict(email="gene@lp.com"), follow_redirects=True)
 
-    user = requests[0]["user"]
     token = requests[0]["token"]
 
     # Delete user
     with app.app_context():
+        # load user (and role) to get into session so cascade delete works.
+        user = app.security.datastore.find_user(email="gene@lp.com")
         sqlalchemy_datastore.delete(user)
         sqlalchemy_datastore.commit()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -76,10 +76,10 @@ def create_roles(ds):
         ("admin", ["full-read", "full-write", "super"]),
         ("editor", ["full-read", "full-write"]),
         ("author", ["full-read", "my-write"]),
-        ("simple", []),
+        ("simple", None),
     ]
     for role in roles:
-        if hasattr(ds.role_model, "permissions"):
+        if hasattr(ds.role_model, "permissions") and role[1]:
             ds.create_role(name=role[0], permissions=",".join(role[1]))
         else:
             ds.create_role(name=role[0])
@@ -93,7 +93,7 @@ def create_users(app, ds, count=None):
         ("dave@lp.com", "dave", "password", ["admin", "editor"], True, 345678, None),
         ("jill@lp.com", "jill", "password", ["author"], True, 456789, None),
         ("tiya@lp.com", "tiya", "password", [], False, 567890, None),
-        ("gene@lp.com", "gene", "password", [], True, 889900, None),
+        ("gene@lp.com", "gene", "password", ["simple"], True, 889900, None),
         ("jess@lp.com", "jess", None, [], True, 678901, None),
         ("gal@lp.com", "gal", "password", ["admin"], True, 112233, "sms"),
         (


### PR DESCRIPTION
If the DB Role had an attribute 'permissions' but it wasn't set - things
didn't work.