### PR TITLE
fix/enhancement - Fix slow auth tokens.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -11,6 +11,8 @@ Core
 ==============================================   =============================================
 ``SECRET_KEY``                                   This is actually part of Flask - but is used by
                                                  Flask-Security to sign all tokens.
+                                                 It is critical this is set to a strong value. For python3
+                                                 consider using: ``secrets.token_urlsafe()``
 ``SECURITY_BLUEPRINT_NAME``                      Specifies the name for the
                                                  Flask-Security blueprint. Defaults to
                                                  ``security``.
@@ -373,106 +375,116 @@ Miscellaneous
 
 .. tabularcolumns:: |p{6.5cm}|p{8.5cm}|
 
-============================================= ==================================
-``SECURITY_USER_IDENTITY_ATTRIBUTES``         Specifies which attributes of the
-                                              user object can be used for login.
-                                              Defaults to ``['email']``.
-``SECURITY_SEND_REGISTER_EMAIL``              Specifies whether registration
-                                              email is sent. Defaults to
-                                              ``True``.
-``SECURITY_SEND_PASSWORD_CHANGE_EMAIL``       Specifies whether password change
-                                              email is sent. Defaults to
-                                              ``True``.
-``SECURITY_SEND_PASSWORD_RESET_EMAIL``        Specifies whether password reset
-                                              email is sent. Defaults to
-                                              ``True``.
-``SECURITY_SEND_PASSWORD_RESET_NOTICE_EMAIL`` Specifies whether password reset
-                                              notice email is sent. Defaults to
-                                              ``True``.
+===================================================== ==================================
+``SECURITY_USER_IDENTITY_ATTRIBUTES``                 Specifies which attributes of the
+                                                      user object can be used for login.
+                                                      Defaults to ``['email']``.
+``SECURITY_SEND_REGISTER_EMAIL``                      Specifies whether registration
+                                                      email is sent. Defaults to
+                                                      ``True``.
+``SECURITY_SEND_PASSWORD_CHANGE_EMAIL``               Specifies whether password change
+                                                      email is sent. Defaults to
+                                                      ``True``.
+``SECURITY_SEND_PASSWORD_RESET_EMAIL``                Specifies whether password reset
+                                                      email is sent. Defaults to
+                                                      ``True``.
+``SECURITY_SEND_PASSWORD_RESET_NOTICE_EMAIL``         Specifies whether password reset
+                                                      notice email is sent. Defaults to
+                                                      ``True``.
 
-``SECURITY_CONFIRM_EMAIL_WITHIN``             Specifies the amount of time a
-                                              user has before their confirmation
-                                              link expires. Always pluralized
-                                              the time unit for this value.
-                                              Defaults to ``5 days``.
-``SECURITY_RESET_PASSWORD_WITHIN``            Specifies the amount of time a
-                                              user has before their password
-                                              reset link expires. Always
-                                              pluralized the time unit for this
-                                              value. Defaults to ``5 days``.
-``SECURITY_LOGIN_WITHIN``                     Specifies the amount of time a
-                                              user has before a login link
-                                              expires. This is only used when
-                                              the passwordless login feature is
-                                              enabled. Always pluralize the
-                                              time unit for this value.
-                                              Defaults to ``1 days``.
-``SECURITY_AUTO_LOGIN_AFTER_CONFIRM``         If ``False`` then on confirmation
-                                              the user will be required to login again. Note that the
-                                              confirmation token is not valid after being used once.
-                                              If ``True``, then the user corresponding to the
-                                              confirmation token will be automatically logged
-                                              in.
-                                              Defaults to ``True``.
-``SECURITY_TWO_FACTOR_GOOGLE_AUTH_VALIDITY``  Specifies the number of seconds access token is
-                                              valid. Defaults to 2 minutes.
-``SECURITY_TWO_FACTOR_MAIL_VALIDITY``         Specifies the number of seconds
-                                              access token is valid. Defaults to 5 minutes.
-``SECURITY_TWO_FACTOR_SMS_VALIDITY``          Specifies the number of seconds access token is
-                                              valid. Defaults to 2 minutes.
-``SECURITY_LOGIN_WITHOUT_CONFIRMATION``       Specifies if a user may login
-                                              before confirming their email when
-                                              the value of
-                                              ``SECURITY_CONFIRMABLE`` is set to
-                                              ``True``. Defaults to ``False``.
-``SECURITY_CONFIRM_SALT``                     Specifies the salt value when
-                                              generating confirmation
-                                              links/tokens. Defaults to
-                                              ``confirm-salt``.
-``SECURITY_RESET_SALT``                       Specifies the salt value when
-                                              generating password reset
-                                              links/tokens. Defaults to
-                                              ``reset-salt``.
-``SECURITY_LOGIN_SALT``                       Specifies the salt value when
-                                              generating login links/tokens.
-                                              Defaults to ``login-salt``.
-``SECURITY_REMEMBER_SALT``                    Specifies the salt value when
-                                              generating remember tokens.
-                                              Remember tokens are used instead
-                                              of user ID's as it is more
-                                              secure. Defaults to
-                                              ``remember-salt``.
-``SECURITY_DEFAULT_REMEMBER_ME``              Specifies the default "remember
-                                              me" value used when logging in
-                                              a user. Defaults to ``False``.
-``SECURITY_TWO_FACTOR_REQUIRED``              If set to ``True`` then all users will be
-                                              required to setup and use two factor authorization.
-                                              Defaults to ``False``.
-``SECURITY_TWO_FACTOR_ENABLED_METHODS``       Specifies the default enabled
-                                              methods for two-factor
-                                              authentication. Defaults to
-                                              ``['mail', 'google_authenticator',
-                                              'sms']`` which are the only
-                                              supported method at the moment.
-``SECURITY_TWO_FACTOR_URI_SERVICE_NAME``      Specifies the name of the service
-                                              or application that the user is
-                                              authenticating to. Defaults to
-                                              ``service_name``
-``SECURITY_TWO_FACTOR_SMS_SERVICE``           Specifies the name of the sms
-                                              service provider. Defaults to
-                                              ``Dummy`` which does nothing.
-``SECURITY_TWO_FACTOR_SMS_SERVICE_CONFIG``    Specifies a dictionary of basic
-                                              configurations needed for use of a
-                                              sms service. Defaults to
-                                              ``{'ACCOUNT_ID': NONE, 'AUTH_TOKEN
-                                              ':NONE, 'PHONE_NUMBER': NONE}``
-``SECURITY_DATETIME_FACTORY``                 Specifies the default datetime
-                                              factory. Defaults to
-                                              ``datetime.datetime.utcnow``.
-``SECURITY_BACKWARDS_COMPAT_UNAUTHN``         If set to ``True`` then the default behavior for authentication
-                                              failures from one of Flask-Security's decorators will be restored to
-                                              be compatibile with prior releases (return 401 and some static html)
-============================================= ==================================
+``SECURITY_CONFIRM_EMAIL_WITHIN``                     Specifies the amount of time a
+                                                      user has before their confirmation
+                                                      link expires. Always pluralized
+                                                      the time unit for this value.
+                                                      Defaults to ``5 days``.
+``SECURITY_RESET_PASSWORD_WITHIN``                    Specifies the amount of time a
+                                                      user has before their password
+                                                      reset link expires. Always
+                                                      pluralized the time unit for this
+                                                      value. Defaults to ``5 days``.
+``SECURITY_LOGIN_WITHIN``                             Specifies the amount of time a
+                                                      user has before a login link
+                                                      expires. This is only used when
+                                                      the passwordless login feature is
+                                                      enabled. Always pluralize the
+                                                      time unit for this value.
+                                                      Defaults to ``1 days``.
+``SECURITY_AUTO_LOGIN_AFTER_CONFIRM``                 If ``False`` then on confirmation
+                                                      the user will be required to login again. Note that the
+                                                      confirmation token is not valid after being used once.
+                                                      If ``True``, then the user corresponding to the
+                                                      confirmation token will be automatically logged
+                                                      in.
+                                                      Defaults to ``True``.
+``SECURITY_TWO_FACTOR_GOOGLE_AUTH_VALIDITY``          Specifies the number of seconds access token is
+                                                      valid. Defaults to 2 minutes.
+``SECURITY_TWO_FACTOR_MAIL_VALIDITY``                 Specifies the number of seconds
+                                                      access token is valid. Defaults to 5 minutes.
+``SECURITY_TWO_FACTOR_SMS_VALIDITY``                  Specifies the number of seconds access token is
+                                                      valid. Defaults to 2 minutes.
+``SECURITY_LOGIN_WITHOUT_CONFIRMATION``               Specifies if a user may login
+                                                      before confirming their email when
+                                                      the value of
+                                                      ``SECURITY_CONFIRMABLE`` is set to
+                                                      ``True``. Defaults to ``False``.
+``SECURITY_CONFIRM_SALT``                             Specifies the salt value when
+                                                      generating confirmation
+                                                      links/tokens. Defaults to
+                                                      ``confirm-salt``.
+``SECURITY_RESET_SALT``                               Specifies the salt value when
+                                                      generating password reset
+                                                      links/tokens. Defaults to
+                                                      ``reset-salt``.
+``SECURITY_LOGIN_SALT``                               Specifies the salt value when
+                                                      generating login links/tokens.
+                                                      Defaults to ``login-salt``.
+``SECURITY_REMEMBER_SALT``                            Specifies the salt value when
+                                                      generating remember tokens.
+                                                      Remember tokens are used instead
+                                                      of user ID's as it is more
+                                                      secure. Defaults to
+                                                      ``remember-salt``.
+``SECURITY_DEFAULT_REMEMBER_ME``                      Specifies the default "remember
+                                                      me" value used when logging in
+                                                      a user. Defaults to ``False``.
+``SECURITY_TWO_FACTOR_REQUIRED``                      If set to ``True`` then all users will be
+                                                      required to setup and use two factor authorization.
+                                                      Defaults to ``False``.
+``SECURITY_TWO_FACTOR_ENABLED_METHODS``               Specifies the default enabled
+                                                      methods for two-factor
+                                                      authentication. Defaults to
+                                                      ``['mail', 'google_authenticator',
+                                                      'sms']`` which are the only
+                                                      supported method at the moment.
+``SECURITY_TWO_FACTOR_URI_SERVICE_NAME``              Specifies the name of the service
+                                                      or application that the user is
+                                                      authenticating to. Defaults to
+                                                      ``service_name``
+``SECURITY_TWO_FACTOR_SMS_SERVICE``                   Specifies the name of the sms
+                                                      service provider. Defaults to
+                                                      ``Dummy`` which does nothing.
+``SECURITY_TWO_FACTOR_SMS_SERVICE_CONFIG``            Specifies a dictionary of basic
+                                                      configurations needed for use of a
+                                                      sms service. Defaults to
+                                                      ``{'ACCOUNT_ID': NONE, 'AUTH_TOKEN
+                                                      ':NONE, 'PHONE_NUMBER': NONE}``
+``SECURITY_DATETIME_FACTORY``                         Specifies the default datetime
+                                                      factory. Defaults to
+                                                      ``datetime.datetime.utcnow``.
+``SECURITY_BACKWARDS_COMPAT_UNAUTHN``                 If set to ``True`` then the default behavior for authentication
+                                                      failures from one of Flask-Security's decorators will be restored to
+                                                      be compatible with releases prior to 3.3.0 (return 401 and some static html).
+                                                      Defaults to ``False``.
+``SECURITY_BACKWARDS_COMPAT_AUTH_TOKEN``              If set to ``True`` then an Authentication-Token will be returned
+                                                      on every successful call to login, reset-password, change-password
+                                                      as part of the JSON response. This was the default prior to release 3.3.0
+                                                      - however sending Authentication-Tokens (which by default don't expire)
+                                                      to session based UIs is a bad security practice.
+                                                      Defaults to ``False``.
+``SECURITY_BACKWARDS_COMPAT_AUTH_TOKEN_INVALIDATE``   When ``True`` changing the user's password will also change the user's
+                                                      ``fs_uniquifier`` (if it exists) such that existing authentication tokens
+                                                      will be rendered invalid.  This restores pre 3.3.0 behavior.
+===================================================== ==================================
 
 Messages
 -------------

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -272,8 +272,8 @@ JSON Response
 +++++++++++++
 Applications that support a JSON based API need to be able to have a uniform
 API response. Flask-Security has a default way to render its API responses - which can
-be easily overridden by either providing a callback function via :meth:`.Security.render_json`.
-As documents in :meth:`Security.render_json`, be aware that Flask-Security registers
+be easily overridden by providing a callback function via :meth:`.Security.render_json`.
+As documented in :meth:`Security.render_json`, be aware that Flask-Security registers
 its own JsonEncoder on its blueprint.
 
 401, 403, Oh My
@@ -281,14 +281,14 @@ its own JsonEncoder on its blueprint.
 For a very long read and discussion; look at `this`_. Out of the box, Flask-Security in
 tandem with Flask-Login, behaves as follows:
 
-    * If authentication fails as the result of a @login_required, @auth_required,
-      @http_auth_required, or @token_auth_required then if the request 'wants' a JSON
+    * If authentication fails as the result of a `@login_required`, `@auth_required`,
+      `@http_auth_required`, or `@token_auth_required` then if the request 'wants' a JSON
       response, :meth:`.Security.render_json` is called with a 401 status code. If not
       then flask_login.LoginManager.unauthorized() is called. By default THAT will redirect to
       a login view.
 
-    * If authorization fails as the result of @roles_required, @roles_accepted,
-      @permissions_required, or @permissions_accepted, then if the request 'wants' a JSON
+    * If authorization fails as the result of `@roles_required`, `@roles_accepted`,
+      `@permissions_required`, or `@permissions_accepted`, then if the request 'wants' a JSON
       response, :meth:`.Security.render_json` is called with a 403 status code. If not,
       then if ``SECURITY_UNAUTHORIZED_VIEW`` is defined, the response will redirected.
       If ``SECURITY_UNAUTHORIZED_VIEW`` is not defined, then ``abort(403)`` is called.

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -59,16 +59,23 @@ Token Authentication
 --------------------
 
 Token based authentication is enabled by retrieving the user auth token by
-performing an HTTP POST with the authentication details as JSON data against the
+performing an HTTP POST with a query param of ``include_auth_token`` with the authentication details
+as JSON data against the
 authentication endpoint. A successful call to this endpoint will return the
 user's ID and their authentication token. This token can be used in subsequent
 requests to protected resources. The auth token is supplied in the request
 through an HTTP header or query string parameter. By default the HTTP header
 name is `Authentication-Token` and the default query string parameter name is
-`auth_token`. Authentication tokens are generated using the user's password.
+`auth_token`. Authentication tokens are generated using a uniquifier field in the
+user's UserModel. If that field is changed (via :meth:`.UserDatastore.set_uniqifier`)
+then any existing authentication tokens will no longer be valid. Changing
+the user's password will not affect tokens.
+
+Note that prior to release 3.3.0 or if the Usermodel doesn't contain the ``fs_uniquifier``
+attribute the authentication tokens are generated using the user's password.
 Thus if the user changes his or her password their existing authentication token
 will become invalid. A new token will need to be retrieved using the user's new
-password.
+password. Verifying tokens created in this way is very slow.
 
 Two-factor Authentication (experimental)
 ----------------------------------------

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -24,6 +24,7 @@ your `User` and `Role` model should include the following fields:
 * ``email``
 * ``password``
 * ``active``
+* ``fs_uniquifier``
 
 
 **Role**

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -29,6 +29,8 @@ paths:
   /login:
     get:
       summary: Retrieve login form and/or user information
+      parameters:
+        - $ref: "#/components/parameters/include_auth_token"
       responses:
         200:
           description: >
@@ -60,6 +62,7 @@ paths:
               URL to redirect to on successful registration. Ignored for json request.
           schema:
             type: string
+        - $ref: "#/components/parameters/include_auth_token"
       requestBody:
         required: true
         content:
@@ -278,6 +281,7 @@ paths:
           in: header
           schema:
             $ref: "#/components/headers/X-CSRF-Token"
+        - $ref: '#/components/parameters/include_auth_token'
       requestBody:
         required: true
         content:
@@ -406,6 +410,8 @@ paths:
                   value: redirect(cv('FORGOT_PASSWORD'))
     post:
       summary: Reset password
+      parameters:
+        - $ref: '#/components/parameters/include_auth_token'
       requestBody:
         required: true
         content:
@@ -557,7 +563,7 @@ components:
           type: object
           required: [id]
           description: >
-            By default just 'id', and 'authentication_token' are returned. However by overriding _User::get_security_payload()_ any attributes of the User model can be returned.
+            By default just 'id'is returned. However by overriding _User::get_security_payload()_ any attributes of the User model can be returned.
           properties:
             id:
               type: integer
@@ -565,7 +571,10 @@ components:
               description: Unique user id (primary key)
             authentication_token:
               type: string
-              description: Token to be used in future token-based API calls.
+              description: >
+                Token to be used in future token-based API calls.
+                Note this only returned from those APIs that accept a
+                'include_auth_token' query param.
         csrf_token:
           type: string
           description: Session CSRF token
@@ -660,6 +669,14 @@ components:
             Email address to send link email to.
   headers:
     X-CSRF-Token:
+      description: CSRF token
+      schema:
+        type: string
+  parameters:
+    include_auth_token:
+      name: include_auth_token
+      description: If set/sent, will return an Authentication Token for user
+      in: query
       schema:
         type: string
 

--- a/flask_security/changeable.py
+++ b/flask_security/changeable.py
@@ -39,6 +39,8 @@ def change_user_password(user, password):
     :param password: The unhashed new password
     """
     user.password = hash_password(password)
+    if config_value("BACKWARDS_COMPAT_AUTH_TOKEN_INVALID"):
+        _datastore.set_uniquifier(user)
     _datastore.put(user)
     send_password_changed_notice(user)
     password_changed.send(current_app._get_current_object(), user=user)

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -232,6 +232,25 @@ class UserDatastore(object):
             return True
         return False
 
+    def set_uniquifier(self, user, uniquifier=None):
+        """ Set user's authentication token uniquifier.
+        This will immediately render outstanding auth tokens invalid.
+
+        :param user: User to modify
+        :param uniquifier: Unique value - if none then uuid.uuid4().hex is used
+
+        This method is a no-op if the user model doesn't contain the attribute
+        ``fs_uniquifier``
+
+        .. versionadded:: 3.3.0
+        """
+        if not hasattr(user, "fs_uniquifier"):
+            return
+        if not uniquifier:
+            uniquifier = uuid.uuid4().hex
+        user.fs_uniquifier = uniquifier
+        self.put(user)
+
     def create_role(self, **kwargs):
         """
         Creates and returns a new role from the given parameters.

--- a/flask_security/models/fsqla.py
+++ b/flask_security/models/fsqla.py
@@ -4,6 +4,9 @@ Copyright 2019 by J. Christopher Wagner (jwag). All rights reserved.
 
 
 Complete models for all features when using Flask-SqlAlchemy
+
+BE AWARE: Once any version of this is shipped no changes can be made - instead
+a new version needs to be created.
 """
 
 import datetime

--- a/flask_security/recoverable.py
+++ b/flask_security/recoverable.py
@@ -100,6 +100,8 @@ def update_password(user, password):
     :param password: The unhashed new password
     """
     user.password = hash_password(password)
+    if config_value("BACKWARDS_COMPAT_AUTH_TOKEN_INVALID"):
+        _datastore.set_uniquifier(user)
     _datastore.put(user)
     send_password_reset_notice(user)
     password_reset.send(app._get_current_object(), user=user)

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -620,6 +620,8 @@ def default_want_json(req):
 class FsJsonEncoder(JSONEncoder):
     """  Flask-Security JSON encoder.
     Extends Flask's JSONencoder to handle lazy-text.
+
+    .. versionadded:: 3.3.0
     """
 
     def default(self, obj):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -33,6 +33,9 @@ class MockUser:
         self.password = password
         self.active = True
 
+    def verify_auth_token(self, data):
+        return True
+
 
 class MockExtensionSecurity:
     @property
@@ -119,6 +122,7 @@ def test_request_loader_not_using_cache(app):
 def test_request_loader_using_cache(app):
     with app.app_context():
         app.config["SECURITY_USE_VERIFY_PASSWORD_CACHE"] = True
+        app.config["SECURITY_BACKWARDS_COMPAT_AUTH_TOKEN"] = True
         app.extensions["security"] = MockExtensionSecurity()
         _request_loader(MockRequest())
         assert local_cache.verify_hash_cache is not None

--- a/tests/test_changeable.py
+++ b/tests/test_changeable.py
@@ -4,13 +4,16 @@
     ~~~~~~~~~~~~~~~
 
     Changeable tests
+
+    :copyright: (c) 2019 by J. Christopher Wagner (jwag).
+    :license: MIT, see LICENSE for more details.
 """
 
 import json
 
 import pytest
 from flask import Flask
-from utils import authenticate, json_authenticate
+from utils import authenticate, json_authenticate, verify_token
 
 from flask_security.core import UserMixin
 from flask_security.signals import password_changed
@@ -194,9 +197,37 @@ def test_token_change(app, client_nc):
         new_password_confirm="newpassword",
     )
     response = client_nc.post(
-        "/change",
+        "/change?include_auth_token=1",
         data=json.dumps(data),
         headers={"Content-Type": "application/json", "Authentication-Token": token},
     )
     assert response.status_code == 200
     assert "authentication_token" in response.jdata["response"]["user"]
+
+
+@pytest.mark.settings(backwards_compat_auth_token_invalid=True)
+def test_bc_password(app, client_nc):
+    # Test behavior of BACKWARDS_COMPAT_AUTH_TOKEN_INVALID
+    response = json_authenticate(client_nc)
+    token = response.jdata["response"]["user"]["authentication_token"]
+    verify_token(client_nc, token)
+
+    data = dict(
+        password="password",
+        new_password="newpassword",
+        new_password_confirm="newpassword",
+    )
+    response = client_nc.post(
+        "/change?include_auth_token=1",
+        data=json.dumps(data),
+        headers={"Content-Type": "application/json", "Authentication-Token": token},
+    )
+    assert response.status_code == 200
+    assert "authentication_token" in response.jdata["response"]["user"]
+
+    # changing password should have rendered existing auth tokens invalid
+    verify_token(client_nc, token, status=401)
+
+    # but new auth token should work
+    token = response.jdata["response"]["user"]["authentication_token"]
+    verify_token(client_nc, token)

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -177,7 +177,7 @@ def test_no_auth_token(client_nc):
     if user isn't confirmed.
     """
     response = client_nc.post(
-        "/register",
+        "/register?include_auth_token",
         data='{"email": "dude@lp.com", "password": "password"}',
         headers={"Content-Type": "application/json"},
     )
@@ -193,7 +193,7 @@ def test_auth_token_unconfirmed(client_nc):
     if user isn't confirmed, but the 'login_without_confirmation' flag is set.
     """
     response = client_nc.post(
-        "/register",
+        "/register?include_auth_token",
         data='{"email": "dude@lp.com", "password": "password"}',
         headers={"Content-Type": "application/json"},
     )

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -80,7 +80,7 @@ def json_login(
         data["csrf_token"] = csrf_token
 
     response = client.post(
-        endpoint or "/login",
+        endpoint or "/login" + "?include_auth_token",
         content_type="application/json",
         data=json.dumps(data),
         headers=headers,

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -6,11 +6,12 @@
     Recoverable functionality tests
 """
 
+import json
 import time
 
 import pytest
 from flask import Flask
-from utils import authenticate, logout
+from utils import authenticate, json_authenticate, json_logout, logout, verify_token
 
 from flask_security.core import UserMixin
 from flask_security.forms import LoginForm
@@ -173,7 +174,7 @@ def test_recoverable_json(app, client, get_message):
 
         # Test submitting a new password
         response = client.post(
-            "/reset/" + token,
+            "/reset/" + token + "?include_auth_token",
             data='{"password": "newpassword",\
                                      "password_confirm": "newpassword"}',
             headers={"Content-Type": "application/json"},
@@ -189,7 +190,7 @@ def test_recoverable_json(app, client, get_message):
 
         # Test logging in with the new password
         response = client.post(
-            "/login",
+            "/login?include_auth_token",
             data='{"email": "joe@lp.com",\
                                      "password": "newpassword"}',
             headers={"Content-Type": "application/json"},
@@ -460,3 +461,38 @@ def test_spa_get_bad_token(app, client, get_message):
         msg = get_message("INVALID_RESET_PASSWORD_TOKEN")
         assert msg == qparams["error"].encode("utf-8")
     assert len(flashes) == 0
+
+
+@pytest.mark.settings(backwards_compat_auth_token_invalid=True)
+def test_bc_password(app, client_nc):
+    # Test behavior of BACKWARDS_COMPAT_AUTH_TOKEN_INVALID
+    response = json_authenticate(client_nc, email="joe@lp.com")
+    token = response.jdata["response"]["user"]["authentication_token"]
+    verify_token(client_nc, token)
+    json_logout(client_nc, token)
+
+    with capture_reset_password_requests() as requests:
+        response = client_nc.post(
+            "/reset",
+            data='{"email": "joe@lp.com"}',
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 200
+
+    reset_token = requests[0]["token"]
+
+    data = dict(password="newpassword", password_confirm="newpassword")
+    response = client_nc.post(
+        "/reset/" + reset_token + "?include_auth_token=1",
+        data=json.dumps(data),
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 200
+    assert "authentication_token" in response.jdata["response"]["user"]
+
+    # changing password should have rendered existing auth tokens invalid
+    verify_token(client_nc, token, status=401)
+
+    # but new auth token should work
+    token = response.jdata["response"]["user"]["authentication_token"]
+    verify_token(client_nc, token)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-    test_respnse
+    test_response
     ~~~~~~~~~~~~~~~~~
 
     Tests for validating default and plugable responses.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,9 @@
     ~~~~~
 
     Test utils
+
+    :copyright: (c) 2019 by J. Christopher Wagner (jwag).
+    :license: MIT, see LICENSE for more details.
 """
 
 from flask import Response as BaseResponse
@@ -37,11 +40,38 @@ def authenticate(
 
 def json_authenticate(client, email="matt@lp.com", password="password", endpoint=None):
     data = '{"email": "%s", "password": "%s"}' % (email, password)
-    return client.post(endpoint or "/login", content_type="application/json", data=data)
+
+    # Get auth token always
+    ep = endpoint or "/login" + "?include_auth_token"
+    return client.post(ep, content_type="application/json", data=data)
+
+
+def verify_token(client_nc, token, status=None):
+    # Use passed auth token in API that requires auth and verify status.
+    # Pass in a client_nc to get valid results.
+    response = client_nc.get(
+        "/token",
+        headers={"Content-Type": "application/json", "Authentication-Token": token},
+    )
+    if status:
+        assert response.status_code == status
+    else:
+        assert b"Token Authentication" in response.data
 
 
 def logout(client, endpoint=None, **kwargs):
     return client.get(endpoint or "/logout", **kwargs)
+
+
+def json_logout(client, token, endpoint=None):
+    return client.post(
+        endpoint or "/logout",
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Authentication-Token": token,
+        },
+    )
 
 
 def get_session(response):


### PR DESCRIPTION
Current auth tokens are slow because they use the user's password (hashed) as a uniquifier (the
user id isn't really enough since it might be reused). This requires checking the (hashed) password against
what is in the token on EVERY request - however hashing is (on purpose) slow. So this can add almost a whole second
to every request!

This PR introduces a new UserModel field - fs_uniquifier - that if present in the UserModel will be populated and used rather than the password. This results in 50x reduction in time when authenticating via token.

Furthermore, the actual token verification has been moved from request_loader into the UserMixin - so
that it could be overridden (creating the auth_token already was in the UserMixin).

Note that this does require a DB migration to add the field. The fsqla model has been updated, and docs
describing at least one way to migrate the DB have been added.

2 new backwards compatibility configurations have been added that can revert some new default behavior.

First - in the past- the auth token was included always in JSON responses to login, reset and change -
even if the caller was a browser. This is
really not great since auth tokens may have very long expire times (or none) and it shouldn't even be sent if not needed.
Now, by default, the auth token is NEVER returned - the caller may request is during login, reset, or change by adding the
'include_auth_token' query param.

Second, since auth tokens used to be checked against the hashed password - changing a user's password meant that any
outstanding auth tokens would be invalidated. That seems like strange behavior - so by default, tokens that are verified
with the new fs_uniquifier won't be invalidated just because the user's password changes. The
BACKWARDS_COMPAT_AUTH_TOKEN_INVALID config variable will cause the fs_uniquifier to be changed whenever the user's password changes, thus restoring the older behavior.

closes: #156 