### PR TITLE
fix - improve performance for auth tokens.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,9 @@ Most have configuration variables that restore prior behavior**.
   to be automatically logged in after confirmation (defaults to True - existing behavior).
 - (:issue:`159`) The ``/register`` endpoint returned the Authentication Token even though
   confirmation was required. This was a huge security hole - it has been fixed.
+- (:pr:`168`) When using the @auth_required or @auth_token_required decorators, the token
+  would be verified twice, and the DB would be queried twice for the user. Given how slow
+  token verification is - this was a significant issue. That has been fixed.
 
 Possible compatibility issues
 +++++++++++++++++++++++++++++
@@ -73,10 +76,10 @@ Possible compatibility issues
     * Since the old Authentication Token algorithm used the (hashed) user's password, those tokens would be invalidated
       whenever the user changed their password. This is not likely to be what most users expect. Since the new
       Authentication Token algorithm doesn't refer to the user's password, changing the user's password won't invalidate
-      outstanding Authentication Tokens. There is a new method and an administrator could use to force changing
-      of a user's ``fs_uniquifier`` - but nothing the user themselves can do to invalidate their Authentication Tokens.
+      outstanding Authentication Tokens. The method :meth:`.UserDatastore.set_uniquifier` can be used by an administrator
+      to change a user's ``fs_uniquifier`` - but nothing the user themselves can do to invalidate their Authentication Tokens.
       Setting the `BACKWARDS_COMPAT_AUTH_TOKEN_INVALIDATE` configuration variable will cause the user's ``fs_uniquifier`` to
-      be changed when they change their password.
+      be changed when they change their password, thus restoring prior behavior.
 
 
 New fast authentication token implementation

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -15,7 +15,6 @@ from functools import wraps
 
 from flask import (
     Response,
-    _app_ctx_stack,
     _request_ctx_stack,
     abort,
     current_app,
@@ -161,8 +160,7 @@ def handle_csrf(method):
         if method in utils.config_value("CSRF_PROTECT_MECHANISMS"):
             _csrf.protect()
         else:
-            ctx = _app_ctx_stack.top
-            ctx.fs_ignore_csrf = True
+            _request_ctx_stack.top.fs_ignore_csrf = True
 
 
 def http_auth_required(realm):
@@ -316,8 +314,7 @@ def unauth_csrf(fall_through=False):
                 utils.config_value("CSRF_IGNORE_UNAUTH_ENDPOINTS")
                 and not current_user.is_authenticated
             ):
-                ctx = _app_ctx_stack.top
-                ctx.fs_ignore_csrf = True
+                _request_ctx_stack.top.fs_ignore_csrf = True
             else:
                 try:
                     _csrf.protect()

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -32,7 +32,7 @@
 """
 
 from flask import (
-    _app_ctx_stack,
+    _request_ctx_stack,
     current_app,
     redirect,
     request,
@@ -146,7 +146,7 @@ def _suppress_form_csrf():
     If app doesn't want CSRF for unauth endpoints then check if caller is authenticated
     or not (many endpoints can be called either way).
     """
-    ctx = _app_ctx_stack.top
+    ctx = _request_ctx_stack.top
     if hasattr(ctx, "fs_ignore_csrf") and ctx.fs_ignore_csrf:
         # This is the case where CsrfProtect was already called (e.g. @auth_required)
         return {"csrf": False}

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -115,8 +115,9 @@ def test_verify_password_cache_set_get(app):
 def test_request_loader_not_using_cache(app):
     with app.app_context():
         app.extensions["security"] = MockExtensionSecurity()
-        _request_loader(MockRequest())
-        assert getattr(local_cache, "verify_hash_cache", None) is None
+        with app.test_request_context("/"):
+            _request_loader(MockRequest())
+            assert getattr(local_cache, "verify_hash_cache", None) is None
 
 
 def test_request_loader_using_cache(app):
@@ -124,6 +125,9 @@ def test_request_loader_using_cache(app):
         app.config["SECURITY_USE_VERIFY_PASSWORD_CACHE"] = True
         app.config["SECURITY_BACKWARDS_COMPAT_AUTH_TOKEN"] = True
         app.extensions["security"] = MockExtensionSecurity()
-        _request_loader(MockRequest())
-        assert local_cache.verify_hash_cache is not None
-        assert local_cache.verify_hash_cache.has_verify_hash_cache(MockUser(1, "token"))
+        with app.test_request_context("/"):
+            _request_loader(MockRequest())
+            assert local_cache.verify_hash_cache is not None
+            assert local_cache.verify_hash_cache.has_verify_hash_cache(
+                MockUser(1, "token")
+            )


### PR DESCRIPTION
Turns out the flask-login will call request_loader if there is no session. That in turn
validates the token, does a DB query for the user, and verifies the contents of the token
(this is the expensive hash check).
Then - if an endpoint is decorated with either @auth_token_required or @auth_required,
it will again call request_loader and do it all over again.

This PR add a request-local flag to note that if the token has been verified and the user
looked up - and simply returns the existing user.

Also - after reading more about request and app contexts - decided that this AND the CSRF
flags (which was added a couple PRs ago) should be in the request context, not the app context.