### PR TITLE
fix - unauthorized_view doesn't accept URL.

### DIFF
--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -13,16 +13,7 @@
 from collections import namedtuple
 from functools import wraps
 
-from flask import (
-    Response,
-    _request_ctx_stack,
-    abort,
-    current_app,
-    g,
-    redirect,
-    request,
-    url_for,
-)
+from flask import Response, _request_ctx_stack, abort, current_app, g, redirect, request
 from flask_login import current_user, login_required  # noqa: F401
 from flask_principal import Identity, Permission, RoleNeed, identity_changed
 from flask_wtf.csrf import CSRFError
@@ -84,7 +75,7 @@ def default_unauthz_handler(func, params):
             view = view()
         else:
             try:
-                view = url_for(view)
+                view = utils.get_url(view)
             except BuildError:
                 view = None
         utils.do_flash(*utils.get_message("UNAUTHORIZED"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,6 +188,10 @@ def app(request):
     def echo_json():
         return jsonify(flask_request.get_json())
 
+    @app.route("/unauthz", methods=["GET", "POST"])
+    def unauthz():
+        return render_template("index.html", content="Unauthorized")
+
     return app
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -211,8 +211,9 @@ def test_unauthorized_access_with_referrer(client, get_message):
     assert response.data.count(get_message("UNAUTHORIZED")) == 1
 
 
-@pytest.mark.settings(unauthorized_view="/")
+@pytest.mark.settings(unauthorized_view="/unauthz")
 def test_roles_accepted(client):
+    # This specificaly tests that we can pass a URL for unauthorized_view.
     for user in ("matt@lp.com", "joe@lp.com"):
         authenticate(client, user)
         response = client.get("/admin_or_editor")
@@ -221,10 +222,10 @@ def test_roles_accepted(client):
 
     authenticate(client, "jill@lp.com")
     response = client.get("/admin_or_editor", follow_redirects=True)
-    assert b"Home Page" in response.data
+    assert b"Unauthorized" in response.data
 
 
-@pytest.mark.settings(unauthorized_view="/")
+@pytest.mark.settings(unauthorized_view="unauthz")
 def test_permissions_accepted(client):
     for user in ("matt@lp.com", "joe@lp.com"):
         authenticate(client, user)
@@ -234,10 +235,10 @@ def test_permissions_accepted(client):
 
     authenticate(client, "jill@lp.com")
     response = client.get("/admin_perm", follow_redirects=True)
-    assert b"Home Page" in response.data
+    assert b"Unauthorized" in response.data
 
 
-@pytest.mark.settings(unauthorized_view="/")
+@pytest.mark.settings(unauthorized_view="unauthz")
 def test_permissions_required(client):
     for user in ["matt@lp.com"]:
         authenticate(client, user)
@@ -247,21 +248,21 @@ def test_permissions_required(client):
 
     authenticate(client, "joe@lp.com")
     response = client.get("/admin_perm_required", follow_redirects=True)
-    assert b"Home Page" in response.data
+    assert b"Unauthorized" in response.data
 
 
-@pytest.mark.settings(unauthorized_view="/")
+@pytest.mark.settings(unauthorized_view="unauthz")
 def test_unauthenticated_role_required(client, get_message):
     response = client.get("/admin", follow_redirects=True)
     assert get_message("UNAUTHORIZED") in response.data
 
 
-@pytest.mark.settings(unauthorized_view="/")
+@pytest.mark.settings(unauthorized_view="unauthz")
 def test_multiple_role_required(client):
     for user in ("matt@lp.com", "joe@lp.com"):
         authenticate(client, user)
         response = client.get("/admin_and_editor", follow_redirects=True)
-        assert b"Home Page" in response.data
+        assert b"Unauthorized" in response.data
         client.get("/logout")
 
     authenticate(client, "dave@lp.com")

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -93,6 +93,8 @@ def create_app():
             locale = request.args.get("lang", None)
             if not locale:
                 locale = request.accept_languages.best
+            if not locale:
+                locale = "en"
             if locale:
                 session["lang"] = locale
         return session.get("lang", None).replace("-", "_")


### PR DESCRIPTION
All other config variables of type xxx_VIEW use utils.get_url() which accepts either an endpoint name or a URL.
For some reason unauthorized_view didn't. This was very confusing for folks.

Add real tests for unauthorized_view (previously they set it to "/" which is the fall-back if the code
can't find the endpoint.

closes: #173 