### PR TITLE
fix - @anonymous_user_required decorator not JSON friendly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ Most have configuration variables that restore prior behavior**.
 - (:issue:`121`) Unauthorization callback not quite right. Split into 2 different callbacks - one for
   unauthorized and one for unauthenticated. Made default unauthenticated handler use Flask-Login's unauthenticated
   method to make everything uniform. Extensive documentation added. :meth:`.Security.unauthorized_callback` has been deprecated.
-- (:pr:`xxx`) Add complete User and Role model mixins that support all features. Modify tests and Quickstart documentation
+- (:pr:`120`) Add complete User and Role model mixins that support all features. Modify tests and Quickstart documentation
   to show how to use these.
 - Improve documentation for :meth:`.UserDatastore.create_user` to make clear that hashed password
   should be passed in.
@@ -34,13 +34,16 @@ Most have configuration variables that restore prior behavior**.
 - (:issue:`127`) JSON response was failing due to LazyStrings in error response.
 - (:issue:`117`) Making a user inactive should stop all access immediately.
 - (:issue:`134`) Confirmation token can no longer be reused. Added
-  `SECURITY_AUTO_LOGIN_AFTER_CONFIRM` option for applications that don't want the user
+  ``SECURITY_AUTO_LOGIN_AFTER_CONFIRM`` option for applications that don't want the user
   to be automatically logged in after confirmation (defaults to True - existing behavior).
 - (:issue:`159`) The ``/register`` endpoint returned the Authentication Token even though
   confirmation was required. This was a huge security hole - it has been fixed.
 - (:pr:`168`) When using the @auth_required or @auth_token_required decorators, the token
   would be verified twice, and the DB would be queried twice for the user. Given how slow
   token verification is - this was a significant issue. That has been fixed.
+- (:issue:`84`) The :func:`.anonymous_user_required` was not JSON friendly - always
+  performing a redirect. Now, if the request 'wants' a JSON response - it will receive a 400 with an error
+  message defined by ``SECURITY_MSG_ANONYMOUS_USER_REQUIRED``.
 
 Possible compatibility issues
 +++++++++++++++++++++++++++++
@@ -48,7 +51,7 @@ Possible compatibility issues
 - (:pr:`120`) :class:`.RoleMixin` now has a method :meth:`.get_permissions` which is called as part
   each request to add Permissions to the authenticated user. It checks if the RoleModel
   has a property ``permissions`` and assumes it is a comma separated string of permissions.
-  If your model already has such a property this will likely fail. You need to override ``get_permissions``
+  If your model already has such a property this will likely fail. You need to override :meth:`.get_permissions`
   and simply return an emtpy set.
 
 - (:issue:`121`) Changes the default (failure) behavior for views protected with @auth_required, @token_auth_required,
@@ -63,6 +66,9 @@ Possible compatibility issues
   on Flask-Security's blueprint by sending it as `json_encoder_cls` as part of initialization. Be aware that your
   JsonEncoder needs to handle LazyStrings (see speaklater).
 
+- (:issue:`84`) Prior to this fix - anytime the decorator :func:`.anonymous_user_required` failed, it caused a redirect to
+  the post_login_view. Now, if the caller wanted a JSON response, it will return a 400.
+
 - (:issue:`156`) Faster Authentication Token introduced 2 non-backwards compatible behavior changes - each can
   be reverted using a configuration variable.
 
@@ -72,13 +78,13 @@ Possible compatibility issues
       be sent this token - even though it was likely ignored. Since these tokens by default have no expiration time
       this exposed a needless security hole. The new default behavior is to ONLY return the Authentication Token from those APIs
       if the query param ``include_auth_token`` is added to the request. Prior behavior can be restored by setting
-      the `BACKWARDS_COMPAT_AUTH_TOKEN` configuration variable.
+      the ``BACKWARDS_COMPAT_AUTH_TOKEN`` configuration variable.
     * Since the old Authentication Token algorithm used the (hashed) user's password, those tokens would be invalidated
       whenever the user changed their password. This is not likely to be what most users expect. Since the new
       Authentication Token algorithm doesn't refer to the user's password, changing the user's password won't invalidate
       outstanding Authentication Tokens. The method :meth:`.UserDatastore.set_uniquifier` can be used by an administrator
       to change a user's ``fs_uniquifier`` - but nothing the user themselves can do to invalidate their Authentication Tokens.
-      Setting the `BACKWARDS_COMPAT_AUTH_TOKEN_INVALIDATE` configuration variable will cause the user's ``fs_uniquifier`` to
+      Setting the ``BACKWARDS_COMPAT_AUTH_TOKEN_INVALIDATE`` configuration variable will cause the user's ``fs_uniquifier`` to
       be changed when they change their password, thus restoring prior behavior.
 
 
@@ -89,7 +95,7 @@ user id isn't really enough since it might be reused). This requires checking th
 what is in the token on EVERY request - however hashing is (on purpose) slow. So this can add almost a whole second
 to every request.
 
-To solve this a new attribute in the User model was added - ``fs_uniquifier``. If this is present in your
+To solve this, a new attribute in the User model was added - ``fs_uniquifier``. If this is present in your
 User model, then it will be used instead of the password for ensuring the token corresponds to the correct user.
 This is very fast. If that attribute is NOT present - then the behavior falls back to existing (slow) method.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,6 +27,8 @@ Core
 
 Protecting Views
 ----------------
+.. autofunction:: flask_security.anonymous_user_required
+
 .. autofunction:: flask_security.http_auth_required
 
 .. autofunction:: flask_security.auth_token_required

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -495,6 +495,7 @@ element is the message and the second element is the error level.
 The default messages and error levels can be found in ``core.py``.
 
 * ``SECURITY_MSG_ALREADY_CONFIRMED``
+* ``SECURITY_MSG_ANONYMOUS_USER_REQUIRED``
 * ``SECURITY_MSG_CONFIRMATION_EXPIRED``
 * ``SECURITY_MSG_CONFIRMATION_REQUEST``
 * ``SECURITY_MSG_CONFIRMATION_REQUIRED``

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -7,6 +7,7 @@
     security via Flask-Login, Flask-Principal, Flask-WTF, and passlib.
 
     :copyright: (c) 2012-2019 by Matt Wright.
+    :copyright: (c) 2019 by J. Christopher Wagner.
     :license: MIT, see LICENSE for more details.
 """
 
@@ -23,6 +24,7 @@ from .datastore import (
 )
 from .decorators import (
     auth_token_required,
+    anonymous_user_required,
     handle_csrf,
     http_auth_required,
     login_required,
@@ -95,6 +97,7 @@ __all__ = (
     "SQLAlchemySessionUserDatastore",
     "Security",
     "UserMixin",
+    "anonymous_user_required",
     "auth_required",
     "auth_token_required",
     "confirm_instructions_sent",

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -287,6 +287,10 @@ _default_messages = {
     "PASSWORD_CHANGE": (_("You successfully changed your password."), "success"),
     "LOGIN": (_("Please log in to access this page."), "info"),
     "REFRESH": (_("Please reauthenticate to access this page."), "info"),
+    "ANONYMOUS_USER_REQUIRED": (
+        _("You can only access this endpoint when not logged in."),
+        "error",
+    ),
     "TWO_FACTOR_INVALID_TOKEN": (_("Invalid Token"), "error"),
     "TWO_FACTOR_LOGIN_SUCCESSFUL": (_("Your token has been confirmed"), "success"),
     "TWO_FACTOR_CHANGE_METHOD_SUCCESSFUL": (

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -502,6 +502,28 @@ def test_login_info(client):
     assert "last_update" in response.jdata["response"]["user"]
 
 
+@pytest.mark.registerable()
+@pytest.mark.settings(post_login_view="/anon_required")
+def test_anon_required(client, get_message):
+    """ If logged in, should get 'anonymous_user_required' redirect """
+    response = authenticate(client, follow_redirects=False)
+    response = client.get("/register")
+    assert "location" in response.headers
+    assert "/anon_required" in response.location
+
+
+@pytest.mark.registerable()
+@pytest.mark.settings(post_login_view="/anon_required")
+def test_anon_required_json(client, get_message):
+    """ If logged in, should get 'anonymous_user_required' response """
+    authenticate(client, follow_redirects=False)
+    response = client.get("/register", headers={"Accept": "application/json"})
+    assert response.status_code == 400
+    assert response.jdata["response"]["errors"].encode("utf-8") == get_message(
+        "ANONYMOUS_USER_REQUIRED"
+    )
+
+
 @pytest.mark.settings(security_hashing_schemes=["sha256_crypt"])
 @pytest.mark.skip
 def test_auth_token_speed(app, client_nc):


### PR DESCRIPTION
With this fix, if the caller wants a JSON response - a 400 with error message will
be returned rather than always redirecting to the post_login_view.

closes: #84