### PR TITLE
feature: Utilize want_json() for responses

### DIFF
--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -293,7 +293,7 @@ tandem with Flask-Login, behaves as follows:
       then if ``SECURITY_UNAUTHORIZED_VIEW`` is defined, the response will redirected.
       If ``SECURITY_UNAUTHORIZED_VIEW`` is not defined, then ``abort(403)`` is called.
 
-All this can be easily changed by defining any or all of :meth:`.Security.render_json`,
+All this can be easily changed by registering any or all of :meth:`.Security.render_json`,
 :meth:`.Security.unauthn_handler` and :meth:`.Security.unauthz_handler`.
 
 The decision on whether to return JSON is based on:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ with io.open("flask_security/__init__.py", "rt", encoding="utf8") as f:
     version = re.search(r'__version__ = "(.*?)"', f.read()).group(1)
 
 tests_require = [
-    "Flask-CLI>=0.4.0",
     "Flask-Mongoengine>=0.9.5",
     "Flask-Peewee>=0.6.5",
     "Flask-SQLAlchemy>=2.3",

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -557,9 +557,12 @@ def test_login_info(client):
     # Make sure we can get user info when logged in already.
 
     json_authenticate(client)
-    response = client.get(
-        "/login", data={}, headers={"Content-Type": "application/json"}
-    )
+    response = client.get("/login", headers={"Content-Type": "application/json"})
+    assert response.status_code == 200
+    assert response.jdata["response"]["user"]["id"] == "1"
+    assert "last_update" in response.jdata["response"]["user"]
+
+    response = client.get("/login", headers={"Accept": "application/json"})
     assert response.status_code == 200
     assert response.jdata["response"]["user"]["id"] == "1"
     assert "last_update" in response.jdata["response"]["user"]


### PR DESCRIPTION
is_json() just looks at Content-Type - which in 90% of cases is fine - but in some
cases (and to be more spec-compliant) we should really be honoring the Accept header.
This adds that into all our view responses.

closes: #155 