### PR TITLE
fix: dont require cachetools unless using cache.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -45,13 +45,13 @@ Core
                                                  ``pbkdf2_sha512``. Defaults to
                                                  ``bcrypt``.
 ``SECURITY_PASSWORD_SCHEMES``                    List of support password hash algorithms.
-                                                 `SECURITY_PASSWORD_HASH` must be from this list.
+                                                 ``SECURITY_PASSWORD_HASH`` must be from this list.
                                                  Passwords encrypted with any of these schemes will be honored.
 ``SECURITY_DEPRECATED_PASSWORD_SCHEMES``         List of password hash algorithms that are considered weak and
                                                  will be accepted, however on first use, will be re-hashed
-                                                 to the current default `SECURITY_PASSWORD_HASH`.
+                                                 to the current default ``SECURITY_PASSWORD_HASH``.
                                                  Default is ``["auto"]`` which means any password found that wasn't
-                                                 hashed using `SECURITY_PASSWORD_HASH` will be re-hashed.
+                                                 hashed using ``SECURITY_PASSWORD_HASH`` will be re-hashed.
 ``SECURITY_PASSWORD_SALT``                       Specifies the HMAC salt. Defaults to
                                                  ``None``.
 ``SECURITY_PASSWORD_SINGLE_HASH``                A list of schemes that should not be hashed
@@ -101,7 +101,11 @@ Core
                                                  verification, which speeds up further
                                                  calls to authenticated routes using
                                                  authentication-token and slow hash algorithms
-                                                 (like bcrypt). Defaults to ``None``
+                                                 (like bcrypt). Defaults to ``None``.
+                                                 If you set this - you must ensure that `cachetools`_ is installed.
+                                                 **Note: this will likely be deprecated and removed in 4.0. It**
+                                                 **has known limitations, and there is now a better/faster way to**
+                                                 **generate and verify auth tokens.**
 ``SECURITY_VERIFY_HASH_CACHE_MAX_SIZE``          Limitation for token validation cache size
                                                  Rules are the ones of TTLCache of
                                                  cachetools package. Defaults to
@@ -150,6 +154,8 @@ Core
 .. _Totp: https://passlib.readthedocs.io/en/stable/narr/totp-tutorial.html#totp-encryption-setup
 .. _set_cookie: https://flask.palletsprojects.com/en/1.1.x/api/?highlight=set_cookie#flask.Response.set_cookie
 .. _axios: https://github.com/axios/axios
+.. _cachetools: https://pypi.org/project/cachetools/
+
 
 URLs and Views
 --------------

--- a/flask_security/cache.py
+++ b/flask_security/cache.py
@@ -9,8 +9,6 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from cachetools import TTLCache
-
 from .utils import config_value
 
 
@@ -23,7 +21,14 @@ class VerifyHashCache:
     def __init__(self):
         ttl = config_value("VERIFY_HASH_CACHE_TTL", default=(60 * 5))
         max_size = config_value("VERIFY_HASH_CACHE_MAX_SIZE", default=500)
-        self._cache = TTLCache(max_size, ttl)
+
+        try:
+            from cachetools import TTLCache
+
+            self._cache = TTLCache(max_size, ttl)
+        except ImportError:
+            # this should have been checked at app init.
+            raise
 
     def has_verify_hash_cache(self, user):
         """Check given user id is in cache."""

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -923,26 +923,23 @@ class Security(object):
         if cv("TWO_FACTOR", app=app):
             if len(cv("TWO_FACTOR_ENABLED_METHODS", app=app)) < 1:
                 raise ValueError("Must configure some TWO_FACTOR_ENABLED_METHODS")
-            self._check_two_factor_modules(
-                "pyqrcode", "TWO_FACTOR", cv("TWO_FACTOR", app=app)
-            )
-            self._check_two_factor_modules(
-                "cryptography", "TWO_FACTOR_SECRET", "has been set"
-            )
+            self._check_modules("pyqrcode", "TWO_FACTOR", cv("TWO_FACTOR", app=app))
+            self._check_modules("cryptography", "TWO_FACTOR_SECRET", "has been set")
 
             if cv("TWO_FACTOR_SMS_SERVICE", app=app) == "Twilio":  # pragma: no cover
-                self._check_two_factor_modules(
+                self._check_modules(
                     "twilio",
                     "TWO_FACTOR_SMS_SERVICE",
                     cv("TWO_FACTOR_SMS_SERVICE", app=app),
                 )
             state.totp_factory(tf_setup(app))
 
+        if cv("USE_VERIFY_PASSWORD_CACHE", app=app):
+            self._check_modules("cachetools", "USE_VERIFY_PASSWORD_CACHE", True)
+
         return state
 
-    def _check_two_factor_modules(
-        self, module, config_name, config_value
-    ):  # pragma: no cover
+    def _check_modules(self, module, config_name, config_value):  # pragma: no cover
         PY3 = sys.version_info[0] == 3
         if PY3:
             from importlib.util import find_spec

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ tests_require = [
     "Flask-Peewee>=0.6.5",
     "Flask-SQLAlchemy>=2.3",
     "bcrypt>=3.1.5",
+    "cachetools>=3.1.0",
     "check-manifest>=0.25",
     "coverage>=4.0",
     "cryptography>=2.3.1",
@@ -61,7 +62,6 @@ install_requires = [
     "Flask-BabelEx>=0.9.3",
     "itsdangerous>=1.1.0",
     "passlib>=1.7.1",
-    "cachetools>=3.1.0",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
Mark caching feature as likely deprecated in 4.0.
First - we now have fast auth tokens and second - there are reports of
issues with it due to multi-threading.