### PR TITLE
fix: Latest peewee relaxed type checking.

### DIFF
--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -486,13 +486,15 @@ class PeeweeUserDatastore(PeeweeDatastore, UserDatastore):
         from peewee import fn as peeweeFn
         from peewee import IntegerField
 
-        try:
-            return self.user_model.get(self.user_model.id == identifier)
-        except (self.user_model.DoesNotExist, ValueError):
-            pass
+        # For peewee we only (currently) support numeric primary keys.
+        if self._is_numeric(identifier):
+            try:
+                return self.user_model.get(self.user_model.id == identifier)
+            except (self.user_model.DoesNotExist, ValueError):
+                pass
 
         for attr in get_identity_attributes():
-            # Read above for why we are checking types.
+            # Read above (SQLAlchemy store) for why we are checking types.
             column = getattr(self.user_model, attr)
             attr_isnumeric = isinstance(column, IntegerField)
             try:


### PR DESCRIPTION
When sending in a non-numeric value for primay key in get_user() - peewee used to
throw an error - now it sends it down to the DB driver. Which in the case of
pyscopg2 causes issues. For peewee we just support numeric primary keys - so
add a quick check.