### PR TITLE
Minor updates.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,25 @@ Flask-Security Changelog
 
 Here you can see the full list of changes between each Flask-Security release.
 
+Version 3.4.0
+-------------
+
+Released TBD
+
+Version 3.3.1
+-------------
+
+Released TBD
+
+- (:pr:`197`) Add `Quart <https://gitlab.com/pgjones/quart/>`_ (Ristellise)
+- (:pr:`194`) Add Python 3.8 support into CI (jdevera)
+- (:pr:`196`) Improve docs around Single Page Applications and react (acidjunk)
+- (:issue:`201`) fsqla model was added to __init__.py making Sqlalchemy a required package.
+   That is wrong and has been removed. Applications must now import flask_security.models
+- (:pr:`999`) Fix/improve examples and quickstart to show one MUST hash_password() when
+   creating users programmatically.
+
+
 Version 3.3.0
 -------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ author = "Matt Wright & Chris Wagner"
 # built documents.
 #
 # The short X.Y version.
-version = "3.3.0"
+version = "3.3.1"
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -64,6 +64,7 @@ The following is a list of all the available context processor decorators:
 * ``change_password_context_processor``: Change password view
 * ``send_confirmation_context_processor``: Send confirmation view
 * ``send_login_context_processor``: Send login view
+* ``mail_context_processor``: Whenever an email will be sent
 * ``tf_setup_context_processor``: Two factor setup view
 * ``tf_token_validation_context_processor``: Two factor token validation view
 * ``tf_verify_password_context_processor``: Two factor password re-verify view

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -35,7 +35,7 @@ possible using Flask-SQLAlchemy and the built-in model mixins:
 
     from flask import Flask, render_template_string
     from flask_sqlalchemy import SQLAlchemy
-    from flask_security import Security, SQLAlchemyUserDatastore, login_required
+    from flask_security import Security, SQLAlchemyUserDatastore, auth_required, hash_password
     from flask_security.models import fsqla
 
     # Create app
@@ -74,12 +74,12 @@ possible using Flask-SQLAlchemy and the built-in model mixins:
     @app.before_first_request
     def create_user():
         db.create_all()
-        user_datastore.create_user(email='test@me.com', password='password')
+        user_datastore.create_user(email="test@me.com", password=hash_password("password"))
         db.session.commit()
 
     # Views
-    @app.route('/')
-    @login_required
+    @app.route("/")
+    @auth_required()
     def home():
         return render_template_string("Hello {{ current_user.email }}")
 
@@ -115,7 +115,7 @@ and models.py. You can also do the models a folder and spread your tables there.
 - app.py ::
 
     from flask import Flask, render_template_string
-    from flask_security import Security, current_user, login_required, \
+    from flask_security import Security, current_user, auth_required, hash_password, \
          SQLAlchemySessionUserDatastore
     from database import db_session, init_db
     from models import User, Role
@@ -128,20 +128,19 @@ and models.py. You can also do the models a folder and spread your tables there.
     app.config['SECURITY_PASSWORD_SALT'] = 'super-secret-random-salt'
 
     # Setup Flask-Security
-    user_datastore = SQLAlchemySessionUserDatastore(db_session,
-                                                    User, Role)
+    user_datastore = SQLAlchemySessionUserDatastore(db_session, User, Role)
     security = Security(app, user_datastore)
 
     # Create a user to test with
     @app.before_first_request
     def create_user():
         init_db()
-        user_datastore.create_user(email='matt@nobien.net', password='password')
+        user_datastore.create_user(email="test@me.com", password=hash_password("password"))
         db_session.commit()
 
     # Views
-    @app.route('/')
-    @login_required
+    @app.route("/")
+    @auth_required()
     def home():
         return render_template_string('Hello {{email}} !', email=current_user.email)
 
@@ -231,7 +230,7 @@ possible using MongoEngine:
     from flask import Flask, render_template
     from flask_mongoengine import MongoEngine
     from flask_security import Security, MongoEngineUserDatastore, \
-        UserMixin, RoleMixin, login_required
+        UserMixin, RoleMixin, auth_required, hash_password
 
     # Create app
     app = Flask(__name__)
@@ -267,11 +266,11 @@ possible using MongoEngine:
     # Create a user to test with
     @app.before_first_request
     def create_user():
-        user_datastore.create_user(email='matt@nobien.net', password='password')
+        user_datastore.create_user(email="admin@me.com", password=hash_password("password"))
 
     # Views
-    @app.route('/')
-    @login_required
+    @app.route("/")
+    @auth_required()
     def home():
         return render_template('index.html')
 
@@ -304,7 +303,7 @@ possible using Peewee:
     from flask_peewee.db import Database
     from peewee import *
     from flask_security import Security, PeeweeUserDatastore, \
-        UserMixin, RoleMixin, login_required
+        UserMixin, RoleMixin, auth_required, hash_password
 
     # Create app
     app = Flask(__name__)
@@ -350,11 +349,11 @@ possible using Peewee:
         for Model in (Role, User, UserRoles):
             Model.drop_table(fail_silently=True)
             Model.create_table(fail_silently=True)
-        user_datastore.create_user(email='matt@nobien.net', password='password')
+        user_datastore.create_user(email="test@me.com", password=hash_password("password"))
 
     # Views
     @app.route('/')
-    @login_required
+    @auth_required()
     def home():
         return render_template('index.html')
 

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -49,7 +49,6 @@ from .forms import (
     TwoFactorVerifyCodeForm,
     TwoFactorVerifyPasswordForm,
 )
-from .models import fsqla
 from .signals import (
     confirm_instructions_sent,
     login_instructions_sent,
@@ -80,7 +79,7 @@ from .utils import (
     verify_and_update_password,
 )
 
-__version__ = "3.3.0"
+__version__ = "3.3.1"
 __all__ = (
     "AnonymousUser",
     "ConfirmRegisterForm",
@@ -103,6 +102,7 @@ __all__ = (
     "confirm_instructions_sent",
     "current_user",
     "handle_csrf",
+    "hash_password",
     "http_auth_required",
     "login_required",
     "login_user",

--- a/flask_security/cli.py
+++ b/flask_security/cli.py
@@ -82,7 +82,7 @@ def roles():
 def users_create(identity, password, active):
     """Create a user."""
     kwargs = {attr: identity for attr in _security.user_identity_attributes}
-    kwargs.update(**{"password": password, "active": "y" if active else ""})
+    kwargs.update(**{"password": password})
 
     form = _security.confirm_register_form(MultiDict(kwargs), meta={"csrf": False})
 

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -1058,6 +1058,9 @@ class Security(object):
         Can raise an exception if it is handled as part of
         flask.errorhandler(<exception>)
 
+        The default implementation will return a 401 response if the request was JSON,
+        otherwise lets flask_login.login_manager.unauthorized() handle redirects.
+
         .. versionadded:: 3.3.0
         """
         self._state._unauthn_handler = cb

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -230,6 +230,9 @@ def auth_required(*auth_methods):
     The first mechanism that succeeds is used, following that, depending on
     configuration, CSRF protection will be tested.
 
+    On authentication failure :meth:`.Security.unauthorized_callback` (deprecated)
+    or :meth:`.Security.unauthn_handler` will be called.
+
     .. versionchanged:: 3.3.0
        If ``auth_methods`` isn't specified, then all will be tried. Authentication
        mechanisms will always be tried in order of ``token``, ``session``, ``basic``


### PR DESCRIPTION
Improve quickstart and examples to show that users MUST call hash_password(password).

Fix bug introduced in 3.3.0 that ended up requiring sqlalchemy to be installed (removed models from __init__.py)

Bumped version to 3.3.1

closes: #201
closes: #202