### PR TITLE
Improvements inspired by integrating with Flask-Admin

### DIFF
--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -115,6 +115,20 @@ The following is a list of all the available form overrides:
 * ``two_factor_verify_password_form``: Two-factor verify password form
 * ``two_factor_rescue_form``: Two-factor help user form
 
+Localization
+------------
+All messages, form labels, and form strings are localizable. Flask-Security uses
+`Flask-BabelEx <https://pythonhosted.org/Flask-BabelEx/>`_ to manage its messages.
+All translations are tagged with a domain, as specified by the configuration variable
+``SECURITY_I18N_DOMAIN`` (default: "security"). For messages and labels all this
+works seamlessly.  For strings inside templates it is necessary to explicitly ask for
+the "security" domain, since your application itself might have its own domain.
+Flask-Security places the method ``_fsdomain`` in jinja2's global environment.
+In order to reference a Flask-Security translation from ANY template (such as if you copied and
+modified an existing security template) just use that method::
+
+    {{ _fsdomain("Login") }}
+
 Emails
 ------
 

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -868,6 +868,8 @@ class Security(object):
             # http://jinja.pocoo.org/docs/2.10/extensions/#i18n-extension
             if "_" not in app.jinja_env.globals:
                 current_app.jinja_env.globals["_"] = state.i18n_domain.gettext
+            # Register so other packages can reference our translations.
+            current_app.jinja_env.globals["_fsdomain"] = state.i18n_domain.gettext
 
         @app.before_first_request
         def _csrf_init():

--- a/tests/templates/_nav.html
+++ b/tests/templates/_nav.html
@@ -1,5 +1,5 @@
 {%- if current_user.is_authenticated -%}
-  <p>{{ _('Welcome') }} {{ current_user.email }}</p>
+  <p>{{ _fsdomain('Welcome') }} {{ current_user.email }}</p>
 {%- endif %}
 <ul>
   <li><a href="{{ url_for('index') }}">Index</a></li>

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -387,10 +387,6 @@ def test_xlation(app, client):
     app.config["BABEL_DEFAULT_LOCALE"] = "fr_FR"
     assert check_xlation(app, "fr_FR"), "You must run python setup.py compile_catalog"
 
-    # This is absolutely not the right way to get translations
-    # initialized - but works for our unit test environment.
-    app.jinja_env.globals["_"] = app.security.i18n_domain.gettext
-
     response = client.get("/login")
     assert b'<label for="password">Mot de passe</label>' in response.data
     response = authenticate(client)
@@ -442,9 +438,6 @@ def test_per_request_xlate(app, client):
             if locale:
                 session["lang"] = locale
         return session.get("lang", None).replace("-", "_")
-
-    # Ugh - this overrides entire app (which is fine for testing).
-    app.jinja_env.globals["_"] = app.security.i18n_domain.gettext
 
     response = client.get("/login", headers=[("Accept-Language", "fr")])
     assert b'<label for="password">Mot de passe</label>' in response.data


### PR DESCRIPTION
Now register '_fsdomain' in the global jinja2 namespace so templates can
easily reference our translations. This is really useful when copying the templates
into an app.

Improved tests so they don't have to override global babel context.

Added section in docs around localization.

Improved view_scaffold:
- don't print to console - flash the info instead.
- generate a real SECRET_KEY as a good example
- remove PASSWORD_SALT - not needed for plaintext!
- use new _fsdomain in local template.

closes: #153 