### PR TITLE
argon2 should also use double hashing.

### DIFF
--- a/examples/fsqlalchemy1.py
+++ b/examples/fsqlalchemy1.py
@@ -35,6 +35,10 @@ app.config["DEBUG"] = True
 # generated using: secrets.token_urlsafe()
 app.config["SECRET_KEY"] = "pf9Wkove4IKEAXvy-cQkeDPhv9Cb3Ag-wyJILbq_dFw"
 app.config["SECURITY_PASSWORD_HASH"] = "argon2"
+# argon2 uses double hashing by default - so provide key.
+# For python3: secrets.SystemRandom().getrandbits(128)
+app.config["SECURITY_PASSWORD_SALT"] = "146585145368132386173505678016728509634"
+
 app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get(
     "SQLALCHEMY_DATABASE_URI", "sqlite://"
 )

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -92,7 +92,6 @@ _default_config = {
         "django_salted_md5",
         "django_salted_sha1",
         "django_des_crypt",
-        "argon2",
         "plaintext",
     },
     "PASSWORD_SCHEMES": [

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -229,6 +229,11 @@ def encrypt_password(password):
 def hash_password(password):
     """Hash the specified plaintext password.
 
+    Unless the hash algorithm is listed in `SECURITY_PASSWORD_SINGLE_HASH`,
+    perform a double hash - first create an HMAC from plaintext, then use
+    hashing algorithm. This satisfies OWASP/ASVS section 2.4.5 - provide 'additional
+    iteration of a key derivation'.
+
     .. versionadded:: 2.0.2
 
     :param password: The plaintext password to hash

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -11,7 +11,7 @@ import timeit
 import pytest
 from pytest import raises
 from utils import authenticate, init_app_with_options
-from passlib.hash import pbkdf2_sha256, django_pbkdf2_sha256, plaintext
+from passlib.hash import argon2, pbkdf2_sha256, django_pbkdf2_sha256, plaintext
 
 from flask_security.utils import hash_password, verify_password, get_hmac
 
@@ -133,6 +133,8 @@ def test_verify_password_argon2(app, sqlalchemy_datastore):
     )
     with app.app_context():
         assert verify_password("pass", hash_password("pass"))
+        # Verify double hash
+        assert verify_password("pass", argon2.hash(get_hmac("pass")))
 
 
 def test_verify_password_argon2_opts(app, sqlalchemy_datastore):


### PR DESCRIPTION
After more research - the double hashing implementation is good and helps
satisfy NIST section 5.1.1.2.