### PR TITLE
Argon2 tweak - up rounds from passlib default of 2 to 10.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -76,7 +76,7 @@ Core
                                                  to the hashing method. This is deprecated as of passlib 1.7.
 ``SECURITY_PASSWORD_HASH_PASSLIB_OPTIONS``       Pass additional options to the various hashing methods. This is a
                                                  dict of the form ``{<scheme>__<option>: <value>, ..}``
-                                                 e.g. {"argon2__rounds": 4}.
+                                                 e.g. {"argon2__rounds": 10}.
 ``SECURITY_EMAIL_SENDER``                        Specifies the email address to send
                                                  emails as. Defaults to value set
                                                  to ``MAIL_DEFAULT_SENDER`` if

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -106,7 +106,9 @@ _default_config = {
         "plaintext",
     ],
     "PASSWORD_HASH_OPTIONS": {},  # Deprecated at passlib 1.7
-    "PASSWORD_HASH_PASSLIB_OPTIONS": {},  # >= 1.7.1 method to pass options.
+    "PASSWORD_HASH_PASSLIB_OPTIONS": {
+        "argon2__rounds": 10  # 1.7.1 default is 2.
+    },  # >= 1.7.1 method to pass options.
     "DEPRECATED_PASSWORD_SCHEMES": ["auto"],
     "LOGIN_URL": "/login",
     "LOGOUT_URL": "/logout",


### PR DESCRIPTION
This seems to be the recommended as of late 2019 - and performing speed tests -
even with 10 rounds it is slightly faster than bcrypt - around 190msecs to hash (on new MacBook Pro).