### PR TITLE
Regenerate the tf_totp_secret upon selecting a new method

### DIFF
--- a/flask_security/twofactor.py
+++ b/flask_security/twofactor.py
@@ -140,17 +140,12 @@ def complete_two_factor_process(user, primary_method, is_changing):
     """clean session according to process (login or changing two-factor method)
      and perform action accordingly
     """
-
-    # only update primary_method and DB if necessary
-    if user.tf_primary_method != primary_method:
-        user.tf_primary_method = primary_method
-        _datastore.put(user)
-
     # if we are changing two-factor method
     if is_changing:
-        # only generate new totp secret if changing method
-        user.tf_totp_secret = generate_totp()
-        _datastore.put(user)
+        # only update primary_method and DB if necessary
+        if user.tf_primary_method != primary_method:
+            user.tf_primary_method = primary_method
+            _datastore.put(user)
 
         # TODO Flashing shouldn't occur here - should be at view level to can
         # make sure not to do it for json requests.


### PR DESCRIPTION
This fixes the issue that the TOTP secret gets regenerated after it has
been set and validated by the user and also ensures that a new secret is
generated every time a new method is selected for 2FA.

Fixes #215 