### PR TITLE
Fix post-login redirect for already authenticated users.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -110,6 +110,8 @@ Then in your browser navigate to::
     http://localhost:8081/docs/_build/html/_static/openapi_view.html
 
 
+Please note that changing ``openapi.yaml`` won't re-trigger a docs build - so you might
+have to manually delete ``docs/_build``.
 
 Testing
 -------

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -54,12 +54,13 @@ paths:
                 example: redirect(SECURITY_POST_LOGIN_VIEW)
     post:
       summary: Login to application
-      description: Supports both json and form request types. If the caller is already logged in, they are logged out and the new user is logged in.
+      description: Supports both json and form request types. If the caller is already logged in, then in the form case, they are redirected to SECURITY_POST_LOGIN_VIEW, for a json
+        request, a 400 is returned.
       parameters:
         - name: next
           in: query
           description: >
-              URL to redirect to on successful registration. Ignored for json request.
+              URL to redirect to on successful login. Ignored for json request.
           schema:
             type: string
         - $ref: "#/components/parameters/include_auth_token"
@@ -82,10 +83,13 @@ paths:
             text/html:
               schema:
                 description: Unsuccessful login
+                type: string
                 example: render_template(SECURITY_LOGIN_USER_TEMPLATE) with error values
         302:
           description: >
-            Success or failure with form data body.
+            Success or failure with form data body OR caller already authenticated/logged in.
+            Note that in the already logged in case, the form body is ignored and the redirect is
+            done in the context/session if the calling user.
             redirect(next) or redirect(SECURITY_POST_LOGIN_VIEW)
           headers:
             Location:
@@ -94,7 +98,7 @@ paths:
                 type: string
                 example: redirect(SECURITY_POST_LOGIN_VIEW)
         400:
-          description: Errors while validating login
+          description: Errors while validating login, or caller already authenticated/logged in.
           content:
             application/json:
               schema:
@@ -128,6 +132,7 @@ paths:
             text/html:
               schema:
                 description: Passwordless login form - with errors.
+                type: string
                 example: render_template(SECURITY_SEND_LOGIN_TEMPLATE)
             application/json:
               schema:
@@ -211,6 +216,7 @@ paths:
           content:
             text/html:
               schema:
+                type: string
                 example: render_template(SECURITY_REGISTER_USER_TEMPLATE)
         302:
           description: Response when already logged in
@@ -249,6 +255,7 @@ paths:
             text/html:
               schema:
                 description: Unsuccessful registration
+                type: string
                 example: render_template(SECURITY_REGISTER_USER_TEMPLATE) with error values
         302:
           description: >
@@ -298,6 +305,7 @@ paths:
             text/html:
               schema:
                 description: Change form validation error.
+                type: string
                 example: render_template(SECURITY_CHANGE_PASSWORD_TEMPLATE) with error values
             application/json:
               schema:
@@ -326,6 +334,7 @@ paths:
           content:
             text/html:
               schema:
+                type: string
                 example: render_template(SECURITY_FORGOT_PASSWORD_TEMPLATE)
         302:
           description: Response when already logged in
@@ -353,6 +362,7 @@ paths:
             text/html:
               schema:
                 description: Forgot password form - with errors.
+                type: string
                 example: render_template(SECURITY_FORGOT_PASSWORD_TEMPLATE)
             application/json:
               schema:
@@ -382,6 +392,7 @@ paths:
           content:
             text/html:
               schema:
+                type: string
                 example: render_template(SECURITY_RESET_PASSWORD_TEMPLATE)
         302:
           description: >
@@ -428,6 +439,7 @@ paths:
             text/html:
               schema:
                 description: Reset form validation error.
+                type: string
                 example: render_template(SECURITY_RESET_PASSWORD_TEMPLATE) with error values
             application/json:
               schema:
@@ -484,6 +496,7 @@ paths:
             text/html:
               schema:
                 description: Confirmation form - with errors.
+                type: string
                 example: render_template(SECURITY_SEND_CONFIRMATION_TEMPLATE)
             application/json:
               schema:

--- a/flask_security/templates/security/_macros.html
+++ b/flask_security/templates/security/_macros.html
@@ -17,7 +17,7 @@
 
 {% macro render_field_errors(field) %}
   <p>
-    {% if field.errors %}
+    {% if field and field.errors %}
       <ul>
       {% for error in field.errors %}
         <li>{{ error }}</li>

--- a/flask_security/templates/security/login_user.html
+++ b/flask_security/templates/security/login_user.html
@@ -1,5 +1,5 @@
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors %}
 
 {% block content %}
 {% include "security/_messages.html" %}
@@ -9,6 +9,7 @@
   {{ render_field_with_errors(login_user_form.email) }}
   {{ render_field_with_errors(login_user_form.password) }}
   {{ render_field_with_errors(login_user_form.remember) }}
+  {{ render_field_errors(login_user_form.csrf_token) }}
   {{ render_field(login_user_form.submit) }}
 </form>
 {% include "security/_menu.html" %}

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -367,8 +367,8 @@ def validate_redirect_url(url):
 
 def get_post_action_redirect(config_key, declared=None):
     urls = [
-        get_url(request.args.get("next")),
-        get_url(request.form.get("next")),
+        get_url(request.args.get("next", None)),
+        get_url(request.form.get("next", None)),
         find_redirect(config_key),
     ]
     if declared:


### PR DESCRIPTION
This was a regression when /login was changed from being decorated with @anonymous_user_required
to handling the already-authenticated case as part of the view.

That has been fixed. A subtle change in behavior is that it not uses
get_post_login_redirect() which will look for 'next' in the form or request params
and that will take precedence over POST_LOGIN_VIEW config setting. This actually makes
things more consistent, since it is EXACTLY the same now as the normal login process.

closes: #221