### PR TITLE
Integrate two-factor auth into registration and confirmation.

### DIFF
--- a/flask_security/twofactor.py
+++ b/flask_security/twofactor.py
@@ -140,20 +140,18 @@ def complete_two_factor_process(user, primary_method, is_changing):
     """clean session according to process (login or changing two-factor method)
      and perform action accordingly
     """
+
+    # only update primary_method and DB if necessary
+    if user.tf_primary_method != primary_method:
+        user.tf_primary_method = primary_method
+        _datastore.put(user)
+
     # if we are changing two-factor method
     if is_changing:
-        # only update primary_method and DB if necessary
-        if user.tf_primary_method != primary_method:
-            user.tf_primary_method = primary_method
-            _datastore.put(user)
-
-        # TODO Flashing shouldn't occur here - should be at view level to can
-        # make sure not to do it for json requests.
         completion_message = "TWO_FACTOR_CHANGE_METHOD_SUCCESSFUL"
         tf_profile_changed.send(
             app._get_current_object(), user=user, method=primary_method
         )
-
     # if we are logging in for the first time
     else:
         completion_message = "TWO_FACTOR_LOGIN_SUCCESSFUL"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,8 +103,12 @@ def app(request):
         return render_template("index.html", content="Home Page")
 
     @app.route("/profile")
-    @login_required
+    @auth_required()
     def profile():
+        if hasattr(app, "security"):
+            if app.security._want_json(flask_request):
+                return jsonify(message="profile")
+
         return render_template("index.html", content="Profile Page")
 
     @app.route("/post_login")

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -62,6 +62,7 @@ def create_app():
     app.config["SECURITY_HASHING_SCHEMES"] = ["hex_md5"]
     app.config["SECURITY_DEPRECATED_HASHING_SCHEMES"] = []
 
+    # Turn on all features (except passwordless since that removes normal login)
     for opt in [
         "changeable",
         "recoverable",
@@ -74,7 +75,12 @@ def create_app():
         app.config["SECURITY_" + opt.upper()] = True
 
     if os.environ.get("SETTINGS"):
+        # Load settings from a file pointed to by SETTINGS
         app.config.from_envvar("SETTINGS")
+    # Allow any SECURITY_ config to be set in environment.
+    for ev in os.environ:
+        if ev.startswith("SECURITY_"):
+            app.config[ev] = os.environ.get(ev)
     mail = Mail(app)
 
     app.json_encoder = JSONEncoder


### PR DESCRIPTION
When two-factor auth is on and required, registration and/or confirmation will no longer
log in the user - but will redirect to 2FA setup.

Also - fixed a bug recently introduced (fixing another bug!) that didn't properly
save primary_method on first login.

Improve view_scaffold a bit to make it easy to set SECURITY configs in the environment for
easier testing.

closes: #223