### PR TITLE
Propagate the remember login option when using 2FA validation

### DIFF
--- a/flask_security/twofactor.py
+++ b/flask_security/twofactor.py
@@ -50,7 +50,13 @@ def tf_clean_session():
     Clean out ALL stuff stored in session (e.g. on logout)
     """
     if config_value("TWO_FACTOR"):
-        for k in ["tf_state", "tf_user_id", "tf_primary_method", "tf_confirmed"]:
+        for k in [
+            "tf_state",
+            "tf_user_id",
+            "tf_primary_method",
+            "tf_confirmed",
+            "tf_remember_login",
+        ]:
             session.pop(k, None)
 
 
@@ -136,7 +142,7 @@ def generate_totp():
     return _security._totp_factory.new().to_json(encrypt=True)
 
 
-def complete_two_factor_process(user, primary_method, is_changing):
+def complete_two_factor_process(user, primary_method, is_changing, remember_login=None):
     """clean session according to process (login or changing two-factor method)
      and perform action accordingly
     """
@@ -158,7 +164,7 @@ def complete_two_factor_process(user, primary_method, is_changing):
         tf_code_confirmed.send(
             app._get_current_object(), user=user, method=primary_method
         )
-        login_user(user)
+        login_user(user, remember=remember_login)
     tf_clean_session()
     return completion_message
 

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -656,6 +656,8 @@ def _two_factor_login(form):
 
     user = form.user
     session["tf_user_id"] = user.id
+    if "remember" in form:
+        session["tf_remember_login"] = form.remember.data
 
     # Set info into form for JSON response
     json_response = {"tf_required": True}
@@ -856,7 +858,9 @@ def two_factor_token_validation():
     setattr(form, "primary_method", pm)
     if form.validate_on_submit():
         # Success - log in user and clear all session variables
-        completion_message = complete_two_factor_process(form.user, pm, changing)
+        completion_message = complete_two_factor_process(
+            form.user, pm, changing, session.pop("tf_remember_login", None)
+        )
         after_this_request(_commit)
         if not request.is_json:
             do_flash(*get_message(completion_message))


### PR DESCRIPTION
This fixes an issues when using a two factor enabled account where the remember login option to store the login beyond a session is not properly propagated through the two factor validation process, thus not allowing two factor enabled accounts to use this option at all. 
To fix this issue this patch stores the remember option data within the session while the validation is done and then logs the user in with it's given choice during the two factor validation completion.

Fixes #229 