### PR TITLE
Two-factor refactoring.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -112,6 +112,9 @@ Utils
 
 .. autoclass:: flask_security.FsJsonEncoder
 
+.. autoclass:: flask_security.Totp
+  :members: get_last_counter, set_last_counter
+
 .. autoclass:: flask_security.SmsSenderBaseClass
   :members: send_sms
 

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -62,6 +62,7 @@ from .signals import (
     user_confirmed,
     user_registered,
 )
+from .totp import Totp
 from .utils import (
     FsJsonEncoder,
     SmsSenderBaseClass,

--- a/flask_security/templates/security/email/two_factor_instructions.html
+++ b/flask_security/templates/security/email/two_factor_instructions.html
@@ -1,3 +1,3 @@
-<p>{{ _("Welcome") }} {{ user.username }}!</p>
+<p>{{ _("Welcome") }} {{ username }}!</p>
 
 <p>{{ _("You can log into your account using the following code:") }} {{ token }}</p>

--- a/flask_security/templates/security/email/two_factor_instructions.txt
+++ b/flask_security/templates/security/email/two_factor_instructions.txt
@@ -1,3 +1,3 @@
-{{ _("Welcome") }} {{ user.username }}!
+{{ _("Welcome") }} {{ username }}!
 
 {{ _("You can log into your account using the following code:") }} {{ token }}

--- a/flask_security/templates/security/two_factor_setup.html
+++ b/flask_security/templates/security/two_factor_setup.html
@@ -13,7 +13,7 @@
             {% endif %}
         {% endfor %}
         {{ render_field_errors(two_factor_setup_form.setup) }}
-        {{ render_field(two_factor_setup_form.submit, value="submit choice") }}
+        {{ render_field(two_factor_setup_form.submit) }}
         {% if chosen_method=="mail" and chosen_method in choices %}
             <p>{{ _("To complete logging in, please enter the code sent to your mail") }}</p>
         {% endif %}
@@ -25,14 +25,14 @@
             <p>{{ _("To Which Phone Number Should We Send Code To?") }}</p>
             {{ two_factor_setup_form.hidden_tag() }}
             {{ render_field_with_errors(two_factor_setup_form.phone, placeholder="enter phone number") }}
-            {{ render_field(two_factor_setup_form.submit, value="submit phone") }}
+            {{ render_field(two_factor_setup_form.submit) }}
         {% endif %}
     </form>
     <form action="{{ url_for_security("two_factor_token_validation") }}" method="POST"
           name="two_factor_verify_code_form">
         {{ two_factor_verify_code_form.hidden_tag() }}
         {{ render_field_with_errors(two_factor_verify_code_form.code) }}
-        {{ render_field(two_factor_verify_code_form.submit, value="submit code") }}
+        {{ render_field(two_factor_verify_code_form.submit) }}
     </form>
     {% include "security/_menu.html" %}
 {% endblock %}

--- a/flask_security/templates/security/two_factor_verify_code.html
+++ b/flask_security/templates/security/two_factor_verify_code.html
@@ -9,7 +9,7 @@
           name="two_factor_verify_code_form">
         {{ two_factor_verify_code_form.hidden_tag() }}
         {{ render_field_with_errors(two_factor_verify_code_form.code, placeholder="enter code") }}
-        {{ render_field(two_factor_verify_code_form.submit, value="submit code") }}
+        {{ render_field(two_factor_verify_code_form.submit) }}
     </form>
     <form action="{{ url_for_security("two_factor_rescue") }}" method="POST" name="two_factor_rescue_form">
         {{ two_factor_rescue_form.hidden_tag() }}
@@ -20,7 +20,7 @@
         {% if problem=="no_mail_access" %}
             <p>{{ _("A mail was sent to us in order to reset your application account") }}</p>
         {% endif %}
-        {{ render_field(two_factor_rescue_form.submit, value="submit") }}
+        {{ render_field(two_factor_rescue_form.submit) }}
     </form>
     {% include "security/_menu.html" %}
 {% endblock %}

--- a/flask_security/templates/security/two_factor_verify_password.html
+++ b/flask_security/templates/security/two_factor_verify_password.html
@@ -8,6 +8,6 @@
           name="two_factor_verify_password_form">
         {{ two_factor_verify_password_form.hidden_tag() }}
         {{ render_field_with_errors(two_factor_verify_password_form.password, placeholder="enter password") }}
-        {{ render_field(two_factor_verify_password_form.submit, value="verify password") }}
+        {{ render_field(two_factor_verify_password_form.submit) }}
     </form>
 {% endblock %}

--- a/flask_security/totp.py
+++ b/flask_security/totp.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""
+    flask_security.totp
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Flask-Security TOTP (Timed-One-Time-Passwords) module
+
+    :copyright: (c) 2019 by J. Christopher Wagner (jwag).
+    :license: MIT, see LICENSE for more details.
+"""
+
+from passlib.totp import TOTP, TokenError
+
+
+class Totp(object):
+    """ Encapsulate usage of Passlib TOTP functionality.
+
+    Flask-Security doesn't implement any replay-attack protection out of the box
+    as suggested by:
+    https://passlib.readthedocs.io/en/stable/narr/totp-tutorial.html#match-verify
+
+    Subclass this and implement the get/set last_counter methods. Your subclass can
+    be registered at Flask-Security creation/initialization time.
+
+    .. versionadded: 3.4.0
+
+    """
+
+    def __init__(self, secrets, issuer):
+        """ Initialize a totp factory.
+        secrets are used to encrypt the per-user totp_secret on disk.
+        """
+        # This should be a dict with at least one entry
+        if not isinstance(secrets, dict) or len(secrets) < 1:
+            raise ValueError("secrets needs to be a dict with at least one entry")
+        self._totp = TOTP.using(issuer=issuer, secrets=secrets)
+
+    def generate_totp_password(self, totp_secret):
+        """Get time-based one-time password on the basis of given secret and time
+        :param totp_secret: the unique shared secret of the user
+        """
+        return self._totp.from_source(totp_secret).generate().token
+
+    def generate_totp_secret(self):
+        """ Create new user-unique totp_secret.
+
+        We return an encrypted json string so that when sent in a cookie or
+        sent to DB - it is encrypted.
+
+        """
+        return self._totp.new().to_json(encrypt=True)
+
+    def verify_totp(self, token, totp_secret, user, window=0):
+        """ Verifies token for specific user.
+
+        :param token: token to be check against user's secret
+        :param totp_secret: the unique shared secret of the user
+        :param user: User model
+        :param window: optional. How far backward and forward in time to search
+         for a match. Measured in seconds.
+        :return: True if match
+        """
+
+        # TODO - in old implementation  using onetimepass window was described
+        # as 'compensate for clock skew) and 'interval_length' would say how long
+        # the token is good for.
+        # In passlib - 'window' means how far back and forward to look and 'clock_skew'
+        # is specifically for well, clock slew.
+        try:
+            tmatch = self._totp.verify(
+                token,
+                totp_secret,
+                window=window,
+                last_counter=self.get_last_counter(user),
+            )
+            self.set_last_counter(user, tmatch)
+            return True
+
+        except TokenError:
+            return False
+
+    def get_totp_uri(self, username, totp_secret):
+        """ Generate provisioning url for use with the qrcode
+                scanner built into the app
+
+        :param username: username/email of the current user
+        :param totp_secret: a unique shared secret of the user
+        """
+        tp = self._totp.from_source(totp_secret)
+        return tp.to_uri(username)
+
+    def get_last_counter(self, user):
+        """ Implement this to fetch stored last_counter from cache.
+
+        :param user: User model
+        :return: last_counter as stored in set_last_counter()
+        """
+        return None
+
+    def set_last_counter(self, user, tmatch):
+        """ Implement this to cache last_counter.
+
+        :param user: User model
+        :param tmatch: a TotpMatch as returned from totp.verify()
+        """
+        pass

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -199,6 +199,11 @@ def verify_and_update_password(password, user):
 
     :param password: A plaintext password to verify
     :param user: The user to verify against
+
+    .. tip::
+        This should not be called directly - rather use
+        :meth:`.UserMixin.verify_and_update_password`
+
     """
     if use_double_hash(user.password):
         verified = _pwd_context.verify(get_hmac(password), user.password)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,7 +22,6 @@ from flask_security.datastore import (
     SQLAlchemyUserDatastore,
     SQLAlchemySessionUserDatastore,
 )
-from flask_security.twofactor import generate_totp
 from flask_security.utils import hash_password
 
 from itsdangerous import URLSafeTimedSerializer
@@ -139,7 +138,7 @@ def create_users(app, ds, count=None):
         ds.commit()
         totp_secret = None
         if app.config.get("SECURITY_TWO_FACTOR", None) and u[6]:
-            totp_secret = generate_totp()
+            totp_secret = app.security._totp_factory.generate_totp_secret()
         user = ds.create_user(
             email=u[0],
             username=u[1],


### PR DESCRIPTION
Pull out totp code into separate class and make that class settable as part
of initial app config.
Add stubs for getting and setting the last_counter so folks can easily add
replay-attack protection.

Also - this will be part of the new passwordless implementation - so wanted
these pieces reusable.

Add calc_username() to UserMixin which calculates an appropriate username based on
the IDENTITY_ATTRIBUTES. This is useful in forms, urls etc (and came from
the recent PR to fix the two-factor qrcode URI).
Modify the twofactor email templates to use this rather than assuming that
all user models have 'username'.

Very minor improvements to localization of some fields in 2FA forms - the submit
buttons label should come from the form definition - not be hard-coded (english).

@Kishi85 If you have a few minutes to look this over - that'd be great.