### PR TITLE
Minor refactor.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -171,19 +171,27 @@ sends the following signals.
     addition to the app (which is the sender), it is passed `user`
     and `method` arguments.
 
+    .. versionadded:: 3.3.0
+
 .. data:: tf_profile_changed
 
-  Sent when two-factor is used and user logs in. In addition to the app
-  (which is the sender), it is passed `user` and `method` arguments.
+    Sent when two-factor is used and user logs in. In addition to the app
+    (which is the sender), it is passed `user` and `method` arguments.
+
+    .. versionadded:: 3.3.0
 
 .. data:: tf_disabled
 
-  Sent when two-factor is disabled. In addition to the app
-  (which is the sender), it is passed `user` argument.
+    Sent when two-factor is disabled. In addition to the app
+    (which is the sender), it is passed `user` argument.
+
+    .. versionadded:: 3.3.0
 
 .. data:: tf_security_token_sent
 
-  Sent when a two factor security/access code is sent. In addition to the app
-  (which is the sender), it is passed `user`, `method`, and `token` arguments.
+    Sent when a two factor security/access code is sent. In addition to the app
+    (which is the sender), it is passed `user`, `method`, and `token` arguments.
+
+    .. versionadded:: 3.3.0
 
 .. _Flask documentation on signals: https://flask.palletsprojects.com/en/1.1.x/signals/

--- a/flask_security/changeable.py
+++ b/flask_security/changeable.py
@@ -29,7 +29,7 @@ def send_password_changed_notice(user):
     """
     if config_value("SEND_PASSWORD_CHANGE_EMAIL"):
         subject = config_value("EMAIL_SUBJECT_PASSWORD_CHANGE_NOTICE")
-        _security.send_mail(subject, user.email, "change_notice", user=user)
+        _security._send_mail(subject, user.email, "change_notice", user=user)
 
 
 def change_user_password(user, password):

--- a/flask_security/confirmable.py
+++ b/flask_security/confirmable.py
@@ -41,7 +41,7 @@ def send_confirmation_instructions(user):
 
     confirmation_link, token = generate_confirmation_link(user)
 
-    _security.send_mail(
+    _security._send_mail(
         config_value("EMAIL_SUBJECT_CONFIRM"),
         user.email,
         "confirmation_instructions",

--- a/flask_security/passwordless.py
+++ b/flask_security/passwordless.py
@@ -30,7 +30,7 @@ def send_login_instructions(user):
     token = generate_login_token(user)
     login_link = url_for_security("token_login", token=token, _external=True)
 
-    _security.send_mail(
+    _security._send_mail(
         config_value("EMAIL_SUBJECT_PASSWORDLESS"),
         user.email,
         "login_instructions",

--- a/flask_security/recoverable.py
+++ b/flask_security/recoverable.py
@@ -37,7 +37,7 @@ def send_reset_password_instructions(user):
     reset_link = url_for_security("reset_password", token=token, _external=True)
 
     if config_value("SEND_PASSWORD_RESET_EMAIL"):
-        _security.send_mail(
+        _security._send_mail(
             config_value("EMAIL_SUBJECT_PASSWORD_RESET"),
             user.email,
             "reset_instructions",
@@ -56,7 +56,7 @@ def send_password_reset_notice(user):
     :param user: The user to send the notice to
     """
     if config_value("SEND_PASSWORD_RESET_NOTICE_EMAIL"):
-        _security.send_mail(
+        _security._send_mail(
             config_value("EMAIL_SUBJECT_PASSWORD_NOTICE"),
             user.email,
             "reset_notice",

--- a/flask_security/registerable.py
+++ b/flask_security/registerable.py
@@ -35,7 +35,7 @@ def register_user(**kwargs):
     user_registered.send(app._get_current_object(), user=user, confirm_token=token)
 
     if config_value("SEND_REGISTER_EMAIL"):
-        _security.send_mail(
+        _security._send_mail(
             config_value("EMAIL_SUBJECT_REGISTER"),
             user.email,
             "welcome",

--- a/flask_security/totp.py
+++ b/flask_security/totp.py
@@ -22,7 +22,7 @@ class Totp(object):
     Subclass this and implement the get/set last_counter methods. Your subclass can
     be registered at Flask-Security creation/initialization time.
 
-    .. versionadded: 3.4.0
+    .. versionadded:: 3.4.0
 
     """
 

--- a/flask_security/twofactor.py
+++ b/flask_security/twofactor.py
@@ -13,7 +13,7 @@ from flask import current_app as app, session
 from werkzeug.local import LocalProxy
 
 from .totp import Totp
-from .utils import send_mail, config_value, SmsSenderFactory, login_user
+from .utils import config_value, SmsSenderFactory, login_user
 from .signals import (
     tf_code_confirmed,
     tf_disabled,
@@ -23,7 +23,6 @@ from .signals import (
 
 # Convenient references
 _security = LocalProxy(lambda: app.extensions["security"])
-
 _datastore = LocalProxy(lambda: _security.datastore)
 
 
@@ -62,7 +61,7 @@ def send_security_token(user, method, totp_secret):
     """
     token_to_be_sent = _security._totp_factory.generate_totp_password(totp_secret)
     if method == "mail":
-        send_mail(
+        _security._send_mail(
             config_value("EMAIL_SUBJECT_TWO_FACTOR"),
             user.email,
             "two_factor_instructions",

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -70,6 +70,19 @@ def test_alt_send_mail(app, sqlalchemy_datastore):
     assert app.mail_sent is True
 
 
+@pytest.mark.recoverable()
+def test_alt_send_mail_decorator(app, client):
+    """ Verify that can override the send_mail method. """
+    app.mail_sent = False
+
+    @app.security.send_mail
+    def send_email(subject, email, template, **kwargs):
+        app.mail_sent = True
+
+    client.post("/reset", data=dict(email="matt@lp.com"))
+    assert app.mail_sent is True
+
+
 def test_register_blueprint_flag(app, sqlalchemy_datastore):
     app.security = Security(app, datastore=Security, register_blueprint=False)
     client = app.test_client()


### PR DESCRIPTION
2FA code wasn't calling _security.send_mail - so that couldn't be easily overridden.

Convert send_mail configuration to match others - internally we call _send_mail - so
we can now configure a send_mail routine using a decorator.

various places in views still called request.is_json rather than _security._want_json(request)
so a) didn't respond to Accept headers and b) couldn't be overridden.