### PR TITLE
Introduce fsqla_v2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,7 +72,7 @@ Please see below for details.**
   unified API responses.
 - (:issue:`121`) Unauthorization callback not quite right. Split into 2 different callbacks - one for
   unauthorized and one for unauthenticated. Made default unauthenticated handler use Flask-Login's unauthenticated
-  method to make everything uniform. Extensive documentation added. :meth:`.Security.unauthorized_callback` has been deprecated.
+  method to make everything uniform. Extensive documentation added. `.Security.unauthorized_callback` has been deprecated.
 - (:pr:`120`) Add complete User and Role model mixins that support all features. Modify tests and Quickstart documentation
   to show how to use these. Please see :ref:`responsetopic` for details.
 - Improve documentation for :meth:`.UserDatastore.create_user` to make clear that hashed password
@@ -90,7 +90,7 @@ Please see below for details.**
 - (:issue:`159`) The ``/register`` endpoint returned the Authentication Token even though
   confirmation was required. This was a huge security hole - it has been fixed.
 - (:issue:`160`) The 2FA totp_secret would be regenerated upon submission, making QRCode not work. (malware-watch)
-- (:issue:`166`) :meth:`.default_render_json` uses ``flask.make_response`` and forces the Content-Type to JSON for generating the response (koekie)
+- (:issue:`166`) `default_render_json` uses ``flask.make_response`` and forces the Content-Type to JSON for generating the response (koekie)
 - (:issue:`166`) *SECURITY_MSG_UNAUTHENTICATED* added to the configuration.
 - (:pr:`168`) When using the @auth_required or @auth_token_required decorators, the token
   would be verified twice, and the DB would be queried twice for the user. Given how slow
@@ -122,7 +122,7 @@ Possible compatibility issues
 - (:issue:`121`) Changes the default (failure) behavior for views protected with @auth_required, @token_auth_required,
   or @http_auth_required. Before, a 401 was returned with some stock html. Now, Flask-Login.unauthorized() is
   called (the same as @login_required does) - which by default redirects to a login page/view. If you had provided your own
-  :meth:`.Security.unauthorized_callback` there are no changes - that will still be called first. The old default
+  `.Security.unauthorized_callback` there are no changes - that will still be called first. The old default
   behavior can be restored by setting *SECURITY_BACKWARDS_COMPAT_UNAUTHN* to True. Please see :ref:`responsetopic` for details.
 
 - (:issue:`127`) Fix for LazyStrings in json error response. The fix for this has Flask-Security registering

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,8 @@ exclude_patterns = ["_build"]
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
 
+nitpicky = True
+nitpick_ignore = [("py:attr", "LoginManager.unauthorized"), ("py:class", "function")]
 
 # -- Options for HTML output ---------------------------------------------
 

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -290,7 +290,7 @@ JSON Response
 Applications that support a JSON based API need to be able to have a uniform
 API response. Flask-Security has a default way to render its API responses - which can
 be easily overridden by providing a callback function via :meth:`.Security.render_json`.
-As documented in :meth:`Security.render_json`, be aware that Flask-Security registers
+As documented in :meth:`.Security.render_json`, be aware that Flask-Security registers
 its own JsonEncoder on its blueprint.
 
 401, 403, Oh My

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -15,6 +15,10 @@ various `best practice` fields - such as update and create times. These mixins c
 be easily extended to add any sort of custom fields and can be found in the
 `models` module (today there is just one for using Flask-SqlAlchemy).
 
+The provided models are versioned since they represent actual DB models, and any
+changes require a schema migration (and perhaps a data migration). Applications
+must specifically import the version they want (and handle any required migration).
+
 At the bare minimum
 your `User` and `Role` model should include the following fields:
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -46,7 +46,7 @@ possible using Flask-SQLAlchemy and the built-in model mixins:
     from flask import Flask, render_template_string
     from flask_sqlalchemy import SQLAlchemy
     from flask_security import Security, SQLAlchemyUserDatastore, auth_required, hash_password
-    from flask_security.models import fsqla
+    from flask_security.models import fsqla_v2 as fsqla
 
     # Create app
     app = Flask(__name__)

--- a/examples/fsqlalchemy1/app.py
+++ b/examples/fsqlalchemy1/app.py
@@ -28,7 +28,7 @@ from flask_security import (
     permissions_required,
     roles_accepted,
 )
-from flask_security.models import fsqla
+from flask_security.models import fsqla_v2 as fsqla
 
 # Create app
 app = Flask(__name__)

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -237,7 +237,7 @@ def auth_required(*auth_methods):
     The first mechanism that succeeds is used, following that, depending on
     configuration, CSRF protection will be tested.
 
-    On authentication failure :meth:`.Security.unauthorized_callback` (deprecated)
+    On authentication failure `.Security.unauthorized_callback` (deprecated)
     or :meth:`.Security.unauthn_handler` will be called.
 
     .. versionchanged:: 3.3.0

--- a/flask_security/models/fsqla.py
+++ b/flask_security/models/fsqla.py
@@ -35,9 +35,14 @@ class FsModels(object):
 
     roles_users = None
     db = None
+    fs_model_version = 1
 
     @classmethod
     def set_db_info(cls, appdb):
+        """ Initialize Model.
+        This needs to be called after the DB object has been created
+        (e.g. db = Sqlalchemy())
+        """
         cls.db = appdb
         cls.roles_users = appdb.Table(
             "roles_users",

--- a/flask_security/models/fsqla_v2.py
+++ b/flask_security/models/fsqla_v2.py
@@ -1,0 +1,53 @@
+"""
+Copyright 2020 by J. Christopher Wagner (jwag). All rights reserved.
+:license: MIT, see LICENSE for more details.
+
+
+Complete models for all features when using Flask-SqlAlchemy
+
+BE AWARE: Once any version of this is shipped no changes can be made - instead
+a new version needs to be created.
+
+This is Version 2:
+    - Add support for passwordless V2.
+    - Make username unique (but not required).
+"""
+
+from sqlalchemy import Column, String
+from sqlalchemy.ext.declarative import declared_attr
+
+
+from .fsqla import FsModels as FsModelsV1
+from .fsqla import FsUserMixin as FsUserMixinV1
+from .fsqla import FsRoleMixin as FsRoleMixinV1
+
+
+class FsModels(FsModelsV1):
+    fs_model_version = 2
+    pass
+
+
+class FsRoleMixin(FsRoleMixinV1):
+    pass
+
+
+class FsUserMixin(FsUserMixinV1):
+    """ User information
+    """
+
+    # Make username unique but not required.
+    username = Column(String(255), unique=True, nullable=True)
+
+    # passwordless v2
+    pl_totp_secret = Column(String(255), nullable=True)
+    pl_phone_number = Column(String(128), nullable=True)
+
+    # This is repeated since I couldn't figure out how to have it reference the
+    # new version of FsModels.
+    @declared_attr
+    def roles(cls):
+        return FsModels.db.relationship(
+            "Role",
+            secondary=FsModels.roles_users,
+            backref=FsModels.db.backref("users", lazy="dynamic"),
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,7 +264,7 @@ def sqlalchemy_datastore(request, app, tmpdir, realdburl):
 
 def sqlalchemy_setup(request, app, tmpdir, realdburl):
     from flask_sqlalchemy import SQLAlchemy
-    from flask_security.models import fsqla
+    from flask_security.models import fsqla_v2 as fsqla
 
     if realdburl:
         db_url, db_info = _setup_realdb(realdburl)


### PR DESCRIPTION
For passwordlessV2 we need new DB fields.

This adds a fsqla_v2 with new fields and formalized how we add versions.
Add some simple tests to verify these mixins only have what we expect.

Convert unit tests, quickstart, examples to use new fsqla_v2.

Improve docs by adding nitpick mode to make sure we don't have unresolved references.