### PR TITLE
Reworked registration form and register_user logic

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -134,6 +134,8 @@ sends the following signals.
 
    Sent when a user registers on the site. In addition to the app (which is the
    sender), it is passed `user`, `confirm_token` and `form_data` arguments.
+   `form_data` is a dictionary representation of registration form's content
+   received with registration request.
 
 .. data:: user_confirmed
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -133,7 +133,7 @@ sends the following signals.
 .. data:: user_registered
 
    Sent when a user registers on the site. In addition to the app (which is the
-   sender), it is passed `user` and `confirm_token` arguments.
+   sender), it is passed `user`, `confirm_token` and `form_data` arguments.
 
 .. data:: user_confirmed
 

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -225,8 +225,7 @@ class RegisterFormMixin:
             is_form_field = isinstance(member, Field)
 
             # Not a form field, return False
-            if is_form_field is False:
-
+            if not is_form_field:
                 return False
 
             # If only fields recorded on UserModel should be returned,

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -225,12 +225,12 @@ class RegisterFormMixin:
             is_form_field = isinstance(member, Field)
 
             # Not a form field, return False
-            if not is_form_field:
+            if is_form_field is False:
 
                 return False
 
             # If only fields recorded on UserModel should be returned,
-            # perform check on user model, else return field
+            # perform check on user model, else return True
             if only_user is True:
 
                 return hasattr(_datastore.user_model, member.name)

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -212,13 +212,34 @@ class NextFormMixin:
 class RegisterFormMixin:
     submit = SubmitField(get_form_field_label("register"))
 
-    def to_dict(form):
-        def is_field_and_user_attr(member):
-            return isinstance(member, Field) and hasattr(
-                _datastore.user_model, member.name
-            )
+    def to_dict(self, only_user):
+        """
+        Return form data as dictionary
+        :param only_user: bool, if True then only fields that have
+        corresponding members in UserModel are returned
+        :return: dict
+        """
 
-        fields = inspect.getmembers(form, is_field_and_user_attr)
+        def is_field_and_user_attr(member):
+
+            is_form_field = isinstance(member, Field)
+
+            # Not a form field, return False
+            if not is_form_field:
+
+                return False
+
+            # If only fields recorded on UserModel should be returned,
+            # perform check on user model, else return field
+            if only_user is True:
+
+                return hasattr(_datastore.user_model, member.name)
+
+            else:
+
+                return True
+
+        fields = inspect.getmembers(self, is_field_and_user_attr)
         return dict((key, value.data) for key, value in fields)
 
 

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -231,11 +231,8 @@ class RegisterFormMixin:
             # If only fields recorded on UserModel should be returned,
             # perform check on user model, else return True
             if only_user is True:
-
                 return hasattr(_datastore.user_model, member.name)
-
             else:
-
                 return True
 
         fields = inspect.getmembers(self, is_field_and_user_attr)

--- a/flask_security/registerable.py
+++ b/flask_security/registerable.py
@@ -22,10 +22,19 @@ _security = LocalProxy(lambda: app.extensions["security"])
 _datastore = LocalProxy(lambda: _security.datastore)
 
 
-def register_user(**kwargs):
+def register_user(registration_form):
+    """
+    Calls datastore to create user, triggers post-registration logic
+    (e.g. sending confirmation link, sending registration mail)
+    :param registration_form: form with user registration data
+    :return: user instance
+    """
+
+    user_model_kwargs = registration_form.to_dict(only_user=True)
+
     confirmation_link, token = None, None
-    kwargs["password"] = hash_password(kwargs["password"])
-    user = _datastore.create_user(**kwargs)
+    user_model_kwargs["password"] = hash_password(user_model_kwargs["password"])
+    user = _datastore.create_user(**user_model_kwargs)
     _datastore.commit()
 
     if _security.confirmable:

--- a/flask_security/registerable.py
+++ b/flask_security/registerable.py
@@ -41,7 +41,12 @@ def register_user(registration_form):
         confirmation_link, token = generate_confirmation_link(user)
         do_flash(*get_message("CONFIRM_REGISTRATION", email=user.email))
 
-    user_registered.send(app._get_current_object(), user=user, confirm_token=token)
+    user_registered.send(
+        app._get_current_object(),
+        user=user,
+        confirm_token=token,
+        form_data=registration_form.to_dict(only_user=False),
+    )
 
     if config_value("SEND_REGISTER_EMAIL"):
         _security._send_mail(

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -216,7 +216,7 @@ def register():
     form = form_class(form_data, meta=suppress_form_csrf())
     if form.validate_on_submit():
         did_login = False
-        user = register_user(**form.to_dict())
+        user = register_user(registration_form=form)
         form.user = user
 
         if not _security.confirmable or _security.login_without_confirmation:

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -216,7 +216,7 @@ def register():
     form = form_class(form_data, meta=suppress_form_csrf())
     if form.validate_on_submit():
         did_login = False
-        user = register_user(registration_form=form)
+        user = register_user(form)
         form.user = user
 
         if not _security.confirmable or _security.login_without_confirmation:

--- a/tests/test_registerable.py
+++ b/tests/test_registerable.py
@@ -14,6 +14,10 @@ from utils import authenticate, logout
 from flask_security.core import UserMixin
 from flask_security.signals import user_registered
 
+from flask_security.forms import RegisterForm, StringField
+
+from flask_security import Security
+
 pytestmark = pytest.mark.registerable()
 
 
@@ -163,3 +167,39 @@ def test_two_factor_json(app, client, get_message):
     assert response.jdata["response"]["error"].encode("utf-8") == get_message(
         "UNAUTHENTICATED"
     )
+
+
+def test_form_data_is_passed_to_user_registered_signal(app, sqlalchemy_datastore):
+    class MyRegisterForm(RegisterForm):
+        additional_field = StringField("additional_field")
+
+    app.security = Security(
+        app, datastore=sqlalchemy_datastore, register_form=MyRegisterForm
+    )
+
+    recorded = []
+
+    @user_registered.connect_via(app)
+    def on_user_registerd(app, user, confirm_token, form_data):
+
+        assert isinstance(app, Flask)
+        assert isinstance(user, UserMixin)
+        assert confirm_token is None
+
+        assert form_data["additional_field"] == "additional_data"
+
+        recorded.append(user)
+
+    client = app.test_client()
+
+    data = dict(
+        email="dude@lp.com",
+        password="password",
+        password_confirm="password",
+        additional_field="additional_data",
+    )
+
+    response = client.post("/register", data=data, follow_redirects=True)
+
+    assert response.status_code == 200
+    assert len(recorded) == 1

--- a/tests/test_registerable.py
+++ b/tests/test_registerable.py
@@ -31,7 +31,7 @@ def test_registerable_flag(client, app, get_message):
 
     # Test registering is successful, sends email, and fires signal
     @user_registered.connect_via(app)
-    def on_user_registerd(app, user, confirm_token, form_data):
+    def on_user_registered(app, user, confirm_token, form_data):
 
         assert isinstance(app, Flask)
         assert isinstance(user, UserMixin)
@@ -77,6 +77,7 @@ def test_registerable_flag(client, app, get_message):
     response = client.post(
         "/register", data=data, headers={"Content-Type": "application/json"}
     )
+
     assert response.headers["content-type"] == "application/json"
     assert response.jdata["meta"]["code"] == 200
     assert len(response.jdata["response"]) == 2

--- a/tests/test_registerable.py
+++ b/tests/test_registerable.py
@@ -27,10 +27,13 @@ def test_registerable_flag(client, app, get_message):
 
     # Test registering is successful, sends email, and fires signal
     @user_registered.connect_via(app)
-    def on_user_registerd(app, user, confirm_token):
+    def on_user_registerd(app, user, confirm_token, form_data):
+
         assert isinstance(app, Flask)
         assert isinstance(user, UserMixin)
         assert confirm_token is None
+        assert len(form_data.keys()) > 0
+
         recorded.append(user)
 
     data = dict(


### PR DESCRIPTION
This is a work in progress PR meant to discuss how to go about implementing https://github.com/jwag956/flask-security/issues/251

Code in here only changes internals, and shouldn't affect any clients.
It adds a way to extract both user model data and all form data from registration form.

The next step would be to expose form data to clients and I would like to ask for ideas on how to do that. Adding that data as say `form_data` argument to `user_registered` signal seems most natural. But it would break clients that use this event - as it would require them to add new argument to their `user_registered` callbacks. Is that fine?
```python
form_data = registration_form.to_dict(only_user=False)
user_registered.send(app._get_current_object(), user=user, confirm_token=token, registration_form_data=form_data)
```

Any preferences/ideas on how to expose form_data without affecting existing clients? Adding a new signal seems a bit silly.
