### PR TITLE
Add support for registering w/o a password.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,10 +6,11 @@ Here you can see the full list of changes between each Flask-Security release.
 Version 3.4.0
 -------------
 
-Released TBD
+Released Target Feb 2020
 
 - (:issue:`99`, :issue:`195`) Support pluggable password validators. Provide a default
   validator that offers complexity and breached support.
+- (:pr:`257`) Support a unified sign in feature. Please see :ref:`unified-sign-in`.
 
 Version 3.3.2
 -------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -848,11 +848,13 @@ Unified Signin
 .. py:data:: SECURITY_US_VERIFY_LINK_URL
 
     This endpoint handles the 'magic link' that is sent when the user requests a code
-    via email. It is mostly just accessed via a ``GET`` from a email reader.
+    via email. It is mostly just accessed via a ``GET`` from an email reader.
 
     Default: ``"/us-verify-link"``
 
 .. py:data:: SECURITY_US_QRCODE_URL
+
+    Used to generate and return a QRcode that can be used to intialize an authenticator app.
 
     Default: ``"/us-qrcode"``
 
@@ -875,8 +877,10 @@ Unified Signin
 .. py:data:: SECURITY_US_ENABLED_METHODS
 
     Specifies the default enabled methods for unified sign in authentication.
+    Be aware that ``password`` only affects this ``SECURITY_US_SIGNIN_URL`` endpoint.
+    Removing it from here won't stop users from using the ``SECURITY_LOGIN_URL`` endpoint.
 
-    Default: ``["email", "authenticator", "sms"]`` - which are the only supported options.
+    Default: ``["password", "email", "authenticator", "sms"]`` - which are the only supported options.
 
 .. py:data:: SECURITY_US_TOKEN_VALIDITY
 
@@ -902,8 +906,8 @@ Additional relevant configuration variables:
       used for identity.
     * :py:data:`SECURITY_USER_IDENTITY_MAPPINGS` - Defines the order and methods for parsing identity.
     * :py:data:`SECURITY_DEFAULT_REMEMBER_ME`
-    * :py:data:`SECURITY_SMS_SERVICE_CONFIG`
     * :py:data:`SECURITY_SMS_SERVICE` - When SMS is enabled in :py:data:`SECURITY_US_ENABLED_METHODS`
+    * :py:data:`SECURITY_SMS_SERVICE_CONFIG`
     * :py:data:`SECURITY_TOTP_SECRETS`
     * :py:data:`SECURITY_TOTP_ISSUER`
     * :py:data:`SECURITY_LOGIN_ERROR_VIEW` - The user is redirected here if

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -107,9 +107,11 @@ known limitations:
     * Limited and incomplete JSON support
     * Not enough documentation to use w/o looking at code
 
-Unified Sign In (beta)
------------------------
-**This feature is in Beta - mostly due to it being brand new and little to no production soaking**
+.. _unified-sign-in:
+
+Unified Sign In
+---------------
+**This feature is in Beta - mostly due to it being brand new and little to no production soak time**
 
 Unified sign in provides a generalized login endpoint that takes an `identity`
 and a `passcode`; where (based on configuration):
@@ -134,8 +136,19 @@ or "something you are" (biometric passcode to unlock your device).
 This effectively means that using a one-time code to sign in, is in fact already two-factor (if using
 SMS or authenticator app). Many large authentication providers already offer this - here is
 `Microsoft's`_ version.
-NOTE: currently the Two-Factor feature can not be used in
-conjunction with unified sign in feature - that will be an enhancement.
+
+Note that by configuring :py:data:`SECURITY_US_ENABLED_METHODS` an application can
+use this endpoint JUST with identity/password or in fact disallow passwords altogether.
+
+`Current Missing Functionality`:
+
+    * The Unified signin endpoint does not currently support 2FA. While this isn't really
+      important for SMS and authenticator authentication methods, it would be useful for
+      password and email confirmation methods.
+    * Change password does not work if a user registers without a password. However
+      forgot-password will allow the user to set a new password.
+    * Registration and Confirmation only work with email - so while you can enable multiple
+      authentication methods, you still have to register with email.
 
 Email Confirmation
 ------------------
@@ -189,6 +202,7 @@ Single Page Applications. More specifically
 JSON is supported for the following operations:
 
 * Login requests
+* Unigied signin requests
 * Registration requests
 * Change password requests
 * Confirmation requests

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -240,7 +240,7 @@ _default_config = {
     "US_POST_SETUP_VIEW": None,
     "US_SIGNIN_TEMPLATE": "security/us_signin.html",
     "US_SETUP_TEMPLATE": "security/us_setup.html",
-    "US_ENABLED_METHODS": ["email", "authenticator", "sms"],
+    "US_ENABLED_METHODS": ["password", "email", "authenticator", "sms"],
     "US_TOKEN_VALIDITY": 120,
     "US_EMAIL_SUBJECT": _("Verification Code"),
     "US_SETUP_WITHIN": "30 minutes",
@@ -935,6 +935,14 @@ class Security(object):
     :param json_encoder_cls: Class to use as blueprint.json_encoder.
      Defaults to :class:`FsJsonEncoder`
     :param totp_cls: Class to use as TOTP factory. Defaults to :class:`Totp`
+
+    .. versionchanged:: 3.4.0
+        ``us_signin_form``, ``us_setup_form``, ``us_setup_verify_form`` added as part of
+        the :ref:`unified-sign-in` feature.
+
+    .. versionchanged:: 3.4.0
+        ``totp_cls`` added to enable application to implement replay protection - see
+        :py:class:`Totp`.
     """
 
     def __init__(self, app=None, datastore=None, register_blueprint=True, **kwargs):
@@ -1237,9 +1245,9 @@ class Security(object):
         """
         Callback for validating a user password.
         This is called on registration as well a change and reset password.
-        For registration, kwargs will be all the form input fields that are attributes
-        of the user model.
-        For reset/change, kwargs will be user=UserModel
+        For registration, ``kwargs`` will be all the form input fields that are
+        attributes of the user model.
+        For reset/change, ``kwargs`` will be user=UserModel
 
         :param cb: Callback function with signature (password, is_register, kwargs)
 
@@ -1251,6 +1259,7 @@ class Security(object):
         if not.
 
         .. versionadded:: 3.4.0
+            Refer to :ref:`pass_validation_topic` for more information.
         """
         self._state._password_validator = cb
 

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -6,7 +6,7 @@
     Flask-Security views module
 
     :copyright: (c) 2012 by Matt Wright.
-    :copyright: (c) 2019 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2020 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 
     CSRF is tricky. By default all our forms have CSRF protection built in via
@@ -211,6 +211,10 @@ def logout():
 def register():
     """View function which handles a registration request."""
 
+    # For some unknown historic reason - if you don't require confirmation
+    # (via email) then you need to type in your password twice. That might
+    # make sense if you can't reset your password but in modern (2020) UX models
+    # don't ask twice.
     if _security.confirmable or request.is_json:
         form_class = _security.confirm_register_form
     else:
@@ -227,6 +231,10 @@ def register():
         user = register_user(form)
         form.user = user
 
+        # The 'auto-login' feature probably should be removed - I can't imagine
+        # an application that would want random email accounts. It has been like this
+        # since the beginning. Note that we still enforce 2FA - however for unified
+        # signin - we adhere to historic behavior.
         if not _security.confirmable or _security.login_without_confirmation:
             if config_value("TWO_FACTOR") and config_value("TWO_FACTOR_REQUIRED"):
                 return _two_factor_login(form)

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -134,15 +134,15 @@ def create_app():
             print("Created User: {} with password {}".format(test_acct, "password"))
 
     @user_registered.connect_via(app)
-    def on_user_registered(myapp, user, confirm_token):
+    def on_user_registered(myapp, user, confirm_token, **extra):
         flash("To confirm {} - go to /confirm/{}".format(user.email, confirm_token))
 
     @reset_password_instructions_sent.connect_via(app)
-    def on_reset(myapp, user, token):
+    def on_reset(myapp, user, token, **extra):
         flash("Go to /reset/{}".format(token))
 
     @tf_security_token_sent.connect_via(app)
-    def on_token_sent(myapp, user, token, method):
+    def on_token_sent(myapp, user, token, method, **extra):
         flash(
             "User {} was sent two factor token {} via {}".format(
                 user.calc_username(), token, method
@@ -150,7 +150,7 @@ def create_app():
         )
 
     @us_security_token_sent.connect_via(app)
-    def on_pl_token_sent(myapp, user, token, method):
+    def on_pl_token_sent(myapp, user, token, method, **extra):
         flash(
             "User {} was sent passwordless token {} via {}".format(
                 user.calc_username(), token, method


### PR DESCRIPTION
Continued integrating unified sign in into other features.

We use an un-guessable password (not an empty) one in the user DB record - this makes sure
we don't let folks log in w/o any password, and keeps the DB Column definition of 'non-null' the same.

Added "password" explicitly as a US_ENABLED_METHODS - this actually allows an admin to NOT allow password login - or to JUST use passwords with this new endpoint.