### PR TITLE
Fix bug where reset/forgot password bypassed 2FA.

### DIFF
--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -547,6 +547,11 @@ def reset_password(token):
     if form.validate_on_submit():
         after_this_request(_commit)
         update_password(user, form.password.data)
+        if config_value("TWO_FACTOR") and (
+            config_value("TWO_FACTOR_REQUIRED")
+            or (form.user.tf_totp_secret and form.user.tf_primary_method)
+        ):
+            return _two_factor_login(form)
         login_user(user)
         if _security._want_json(request):
             login_form = _security.login_form(MultiDict({"email": user.email}))


### PR DESCRIPTION
Simple as that - upon successful reset password - the user would have been
immediately authenticated and signed in - thus bypassing 2FA.

This has been fixed - the user now is redirected to the 2FA validation page.