### PR TITLE
Add phone number utility.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -129,6 +129,9 @@ Utils
 .. autoclass:: flask_security.Totp
   :members: get_last_counter, set_last_counter
 
+.. autoclass:: flask_security.PhoneUtil
+  :members:
+
 .. autoclass:: flask_security.SmsSenderBaseClass
   :members: send_sms
 
@@ -139,6 +142,11 @@ Signals
 -------
 See the `Flask documentation on signals`_ for information on how to use these
 signals in your code.
+
+.. tip::
+
+    Remember to add ``**extra_args`` to your signature so that if we add
+    additional parameters in the future your code doesn't break.
 
 See the documentation for the signals provided by the Flask-Login and
 Flask-Principal extensions. In addition to those signals, Flask-Security

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -266,7 +266,7 @@ These configuration keys are used globally across all features.
 .. py:data:: SECURITY_USER_IDENTITY_MAPPINGS
 
     Defines the order and matching that will be applied when validating the
-    (unified/passwordless) login form. This form has a single ``identity`` field
+    unified sign in form. This form has a single ``identity`` field
     that is parsed using the information below - the FIRST match will then be
     used to look up the user in the DB.
 
@@ -354,6 +354,16 @@ These are used by the Two-Factor and Unified Signin features.
 
     .. versionadded:: 3.4.0
 
+.. py:data:: SECURITY_PHONE_REGION_DEFAULT
+
+    Assigns a default 'region' for phone numbers used for two-factor or
+    unified sign in. All other phone numbers will require a region prefix to
+    be accepted.
+
+    Default: ``US``
+
+    .. versionadded:: 3.4.0
+
 Core - rarely need changing
 ----------------------------
 
@@ -419,7 +429,8 @@ Core - rarely need changing
 
     Specifies whether to set the ``UserModel.roles`` loading relationship to ``joined`` when a ``roles`` attribute
     is present for a SQLAlchemy Datastore. Setting this to ``False`` restores pre 3.3.0 behavior and is required if the ``roles`` attribute
-    is not a joinable attribute on the ``UserModel``
+    is not a joinable attribute on the ``UserModel``. The default setting improves performance by only requiring a single
+    DB call.
 
     Default: ``True``.
 
@@ -910,6 +921,7 @@ Additional relevant configuration variables:
     * :py:data:`SECURITY_SMS_SERVICE_CONFIG`
     * :py:data:`SECURITY_TOTP_SECRETS`
     * :py:data:`SECURITY_TOTP_ISSUER`
+    * :py:data:`SECURITY_PHONE_REGION_DEFAULT`
     * :py:data:`SECURITY_LOGIN_ERROR_VIEW` - The user is redirected here if
       :py:data:`SECURITY_US_VERIFY_LINK_URL` has an error and the request is json and
       :py:data:`SECURITY_REDIRECT_BEHAVIOR` equals ``"spa"``.
@@ -1070,6 +1082,7 @@ The default messages and error levels can be found in ``core.py``.
 * ``SECURITY_MSG_PASSWORD_RESET_EXPIRED``
 * ``SECURITY_MSG_PASSWORD_RESET_REQUEST``
 * ``SECURITY_MSG_PASSWORD_TOO_SIMPLE``
+* ``SECURITY_MSG_PHONE_INVALID``
 * ``SECURITY_MSG_REFRESH``
 * ``SECURITY_MSG_RETYPE_PASSWORD_MISMATCH``
 * ``SECURITY_MSG_TWO_FACTOR_INVALID_TOKEN``
@@ -1083,7 +1096,6 @@ The default messages and error levels can be found in ``core.py``.
 * ``SECURITY_MSG_UNAUTHORIZED``
 * ``SECURITY_MSG_UNAUTHENTICATED``
 * ``SECURITY_MSG_US_METHOD_NOT_AVAILABLE``
-* ``SECURITY_MSG_US_PHONE_REQUIRED``
 * ``SECURITY_MSG_US_SETUP_EXPIRED``
 * ``SECURITY_MSG_US_SETUP_SUCCESSFUL``
 * ``SECURITY_MSG_US_SPECIFY_IDENTITY``

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -140,7 +140,7 @@ SMS or authenticator app). Many large authentication providers already offer thi
 Note that by configuring :py:data:`SECURITY_US_ENABLED_METHODS` an application can
 use this endpoint JUST with identity/password or in fact disallow passwords altogether.
 
-`Current Missing Functionality`:
+`Current Limited Functionality`:
 
     * The Unified signin endpoint does not currently support 2FA. While this isn't really
       important for SMS and authenticator authentication methods, it would be useful for

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -7,7 +7,7 @@
     security via Flask-Login, Flask-Principal, Flask-WTF, and passlib.
 
     :copyright: (c) 2012-2019 by Matt Wright.
-    :copyright: (c) 2019 by J. Christopher Wagner.
+    :copyright: (c) 2019-2020 by J. Christopher Wagner.
     :license: MIT, see LICENSE for more details.
 """
 
@@ -49,6 +49,7 @@ from .forms import (
     TwoFactorVerifyCodeForm,
     TwoFactorVerifyPasswordForm,
 )
+from .phone_util import PhoneUtil
 from .signals import (
     confirm_instructions_sent,
     login_instructions_sent,
@@ -64,12 +65,12 @@ from .signals import (
     user_confirmed,
     user_registered,
 )
+from .totp import Totp
 from .unified_signin import (
     UnifiedSigninForm,
     UnifiedSigninSetupForm,
     UnifiedSigninSetupVerifyForm,
 )
-from .totp import Totp
 from .utils import (
     FsJsonEncoder,
     SmsSenderBaseClass,

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -490,6 +490,9 @@ class TwoFactorSetupForm(Form, UserEmailFormMixin):
         super(TwoFactorSetupForm, self).__init__(*args, **kwargs)
 
     def validate(self):
+        # TODO: the super class validate is never called - thus we have to
+        # initialize errors to lists below. It also means that 'email' is never
+        # validated - though it isn't required so the mixin might not be correct.
         choices = config_value("TWO_FACTOR_ENABLED_METHODS")
         if not config_value("TWO_FACTOR_REQUIRED"):
             choices.append("disable")
@@ -497,6 +500,12 @@ class TwoFactorSetupForm(Form, UserEmailFormMixin):
             self.setup.errors = list()
             self.setup.errors.append(get_message("TWO_FACTOR_METHOD_NOT_AVAILABLE")[0])
             return False
+        if self.setup.data == "sms":
+            msg = _security._phone_util.validate_phone_number(self.phone.data)
+            if msg:
+                self.phone.errors = list()
+                self.phone.errors.append(msg)
+                return False
 
         return True
 

--- a/flask_security/phone_util.py
+++ b/flask_security/phone_util.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""
+    flask_security.phone_util
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Utility class for managing phone numbers
+
+    :copyright: (c) 2020 by J. Christopher Wagner (jwag).
+    :license: MIT, see LICENSE for more details.
+
+    Avoid making 'phonenumbers' a required package unless needed.
+"""
+
+from .utils import config_value, get_message
+
+
+class PhoneUtil(object):
+    """
+    Provide parsing and validation for user inputted phone numbers.
+    Subclass this to use a different underlying phone number parsing library.
+
+    To provide your own implementation, pass in the class as ``phone_util_cls``
+    at init time. Your class will be instantiated once prior to the first
+    request being handled.
+
+    .. versionadded:: 3.4.0
+    """
+
+    def validate_phone_number(self, input_data):
+        """ Return ``None`` if a valid phone number else an error message. """
+        import phonenumbers
+
+        try:
+            z = phonenumbers.parse(
+                input_data, region=config_value("PHONE_REGION_DEFAULT")
+            )
+            if phonenumbers.is_valid_number(z):
+                return None
+        except phonenumbers.phonenumberutil.NumberParseException:
+            pass
+        return get_message("PHONE_INVALID")[0]
+
+    def get_canonical_form(self, input_data):
+        """ Validate and return a canonical form to be stored in DB
+        and compared against.
+        Returns ``None`` if input isn't a valid phone number.
+        """
+        import phonenumbers
+
+        try:
+            z = phonenumbers.parse(
+                input_data, region=config_value("PHONE_REGION_DEFAULT")
+            )
+            if phonenumbers.is_valid_number(z):
+                return phonenumbers.format_number(
+                    z, phonenumbers.PhoneNumberFormat.E164
+                )
+            return None
+        except phonenumbers.phonenumberutil.NumberParseException:
+            return None

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -180,7 +180,7 @@ class UnifiedSigninForm(Form):
                 return False
             if self.chosen_method.data == "sms" and not self.user.us_phone_number:
                 # They need to us-setup!
-                self.chosen_method.errors.append(get_message("US_PHONE_REQUIRED")[0])
+                self.chosen_method.errors.append(get_message("PHONE_INVALID")[0])
                 return False
             return True
         return False  # pragma: no cover
@@ -218,9 +218,9 @@ class UnifiedSigninSetupForm(Form):
             return False
 
         if self.chosen_method.data == "sms":
-            # XXX use phone validator
-            if self.phone.data is None or len(self.phone.data) == 0:
-                self.phone.errors.append(get_message("US_PHONE_REQUIRED")[0])
+            msg = _security._phone_util.validate_phone_number(self.phone.data)
+            if msg:
+                self.phone.errors.append(msg)
                 return False
 
         return True
@@ -449,7 +449,7 @@ def us_setup():
         state = {
             "totp_secret": totp,
             "chosen_method": form.chosen_method.data,
-            "phone_number": form.phone.data,
+            "phone_number": _security._phone_util.get_canonical_form(form.phone.data),
         }
         send_security_token(
             user=current_user,

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ tests_require = [
     "mongomock>=3.14.0",
     "msgcheck>=2.9",
     "pony>=0.7.11",
+    "phonenumberslite>=8.11.1",
     "psycopg2>=2.8.4",
     "pydocstyle>=1.0.0",
     "pymysql>=0.9.3",

--- a/tests/test_two_factor.py
+++ b/tests/test_two_factor.py
@@ -309,7 +309,7 @@ def test_two_factor_flag(app, client):
 
     # check appearence of setup page when sms picked and phone number entered
     sms_sender = SmsSenderFactory.createSender("test")
-    data = dict(setup="sms", phone="+111111111111")
+    data = dict(setup="sms", phone="+442083661177")
     response = client.post("/tf-setup", data=data, follow_redirects=True)
     assert b"To Which Phone Number Should We Send Code To" in response.data
     assert sms_sender.get_count() == 1
@@ -470,7 +470,7 @@ def test_opt_in(app, client):
 
     # opt-in for SMS 2FA - but we haven't re-verified password
     sms_sender = SmsSenderFactory.createSender("test")
-    data = dict(setup="sms", phone="+111111111111")
+    data = dict(setup="sms", phone="+442083661177")
     response = client.post("/tf-setup", data=data, follow_redirects=True)
     message = b"You currently do not have permissions to access this page"
     assert message in response.data
@@ -480,7 +480,7 @@ def test_opt_in(app, client):
     response = client.post(
         "/tf-confirm", data=dict(password=password), follow_redirects=True
     )
-    data = dict(setup="sms", phone="+111111111111")
+    data = dict(setup="sms", phone="+442083661177")
     response = client.post("/tf-setup", data=data, follow_redirects=True)
     assert b"To Which Phone Number Should We Send Code To" in response.data
     assert sms_sender.get_count() == 1
@@ -589,7 +589,7 @@ def test_datastore(app, client):
     assert session["tf_state"] == "setup_from_login"
 
     # setup
-    data = dict(setup="sms", phone="+111111111111")
+    data = dict(setup="sms", phone="+442083661177")
     response = client.post(
         "/tf-setup", data=json.dumps(data), headers={"Content-Type": "application/json"}
     )
@@ -611,7 +611,7 @@ def test_datastore(app, client):
     with app.app_context():
         user = app.security.datastore.find_user(email="gene@lp.com")
         assert user.tf_primary_method == "sms"
-        assert user.tf_phone_number == "+111111111111"
+        assert user.tf_phone_number == "+442083661177"
         assert "enckey" in user.tf_totp_secret
 
 
@@ -641,8 +641,8 @@ def test_totp_secret_generation(app, client):
     response = client.post(
         "/tf-confirm", data=dict(password=password), follow_redirects=True
     )
-    # Select sms method but do not send a phone number just yet (regenerates secret)
-    data = dict(setup="sms")
+    # Select sms method (regenerates secret)
+    data = dict(setup="sms", phone="+442083661177")
     response = client.post("/tf-setup", data=data, follow_redirects=True)
     assert b"To Which Phone Number Should We Send Code To" in response.data
 
@@ -656,8 +656,8 @@ def test_totp_secret_generation(app, client):
             generated_secret = user.tf_totp_secret
     assert "enckey" in generated_secret
 
-    # Send the phone number in the second step, method remains unchanged
-    data = dict(setup="sms", phone="+111111111111")
+    # Send a new phone number in the second step, method remains unchanged
+    data = dict(setup="sms", phone="+442083661188")
     response = client.post("/tf-setup", data=data, follow_redirects=True)
     assert sms_sender.get_count() == 1
     code = sms_sender.messages[0].split()[-1]

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -2,7 +2,7 @@
 # :license: MIT, see LICENSE for more details.
 
 """
-This is simple scaffold that can be run as an app and manually test
+This is a simple scaffold that can be run as an app and manually test
 various views using a browser.
 It can be used to test translations by adding ?lang=xx. You might need to
 delete the session cookie if you need to switch between languages (it is easy to
@@ -15,7 +15,6 @@ Runs on port 5001
 An initial user: test@test.com/password is created.
 If you want to register a new user - you will receive a 'flash' that has the
 confirm URL (with token) you need to enter into your browser address bar.
-
 
 Since we don't actually send email - we have signal handlers flash the required
 data and a mail sender that flashes what mail would be sent!


### PR DESCRIPTION
For unified signup - the user can use a phone number as an identity - so it is
important to canonicalize the input date so that minor formatting differences
don't make it impossible to look up.

Add a PhoneUtil class that uses phonenumberslite to implement validation and
canonicalization. Allow this class to be replaced as part of initialization.

Converted two-factor to use this as well for validation of input phone numbers.

Minor other documentation fixes.

closes: #250