### PR TITLE
Add two-factor support to unified sign in.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,21 @@ Released Target Feb 2020
 - (:issue:`99`, :issue:`195`) Support pluggable password validators. Provide a default
   validator that offers complexity and breached support.
 - (:pr:`257`) Support a unified sign in feature. Please see :ref:`unified-sign-in`.
+- (:pr:`265`) Add phone number validation class. This is used in both unified sign in
+  as well as two-factor when using ``sms``.
+
+As part of adding unified sign in - there were many similarities with two-factor.
+Some refactoring was done to unify naming, some configuration variables etc.
+It should all be backwards compatible.
+
+- In TWO_FACTOR_ENABLED_METHODS "mail" was changed to "email". "mail" will still
+  be honored if already stored in DB. Also "google_authenticator" is now just "authenticator".
+- TWO_FACTOR_SECRET, TWO_FACTOR_URI_SERVICE_NAME, TWO_FACTOR_SMS_SERVICE, and TWO_FACTOR_SMS_SERVICE_CONFIG
+  have all been deprecated in favor of names that are the same for two-factor and unified sign in.
+
+Other changes with possible backwards compatibility issues:
+
+- ``/tf-setup`` never did any phone number validation. Now it does.
 
 Version 3.3.2
 -------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -124,6 +124,8 @@ Utils
 
 .. autofunction:: flask_security.transform_url
 
+.. autofunction:: flask_security.us_send_security_token
+
 .. autoclass:: flask_security.FsJsonEncoder
 
 .. autoclass:: flask_security.Totp
@@ -151,6 +153,16 @@ signals in your code.
 See the documentation for the signals provided by the Flask-Login and
 Flask-Principal extensions. In addition to those signals, Flask-Security
 sends the following signals.
+
+.. data:: user_authenticated
+
+    Sent when a user successfully authenticates. In addition to the app (which is the
+    sender), it is passed `user`, and `authn_via` arguments. The `authn_via` argument
+    specifies how the user authenticated - it will be a list with possible values
+    of ``password``, ``sms``, ``authenticator``, ``email``, ``confirm``, ``reset``,
+    ``register``.
+
+    .. versionadded:: 3.4.0
 
 .. data:: user_registered
 
@@ -221,7 +233,8 @@ sends the following signals.
 .. data:: us_security_token_sent
 
     Sent when a unified sign in access code is sent. In addition to the app
-    (which is the sender), it is passed `user`, `method`, and `token` arguments.
+    (which is the sender), it is passed `user`, `method`, `token`,
+    `phone_number`, and `send_magic_link` arguments.
 
     .. versionadded:: 3.4.0
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -732,7 +732,7 @@ Configuration related to the two-factor authentication feature.
 
     Specifies the default enabled methods for two-factor authentication.
 
-    Default: ``['mail', 'authenticator', 'sms']`` which are the only currently supported methods.
+    Default: ``['email', 'authenticator', 'sms']`` which are the only currently supported methods.
 
 .. py:data:: SECURITY_TWO_FACTOR_SECRET
 
@@ -892,6 +892,15 @@ Unified Signin
     Removing it from here won't stop users from using the ``SECURITY_LOGIN_URL`` endpoint.
 
     Default: ``["password", "email", "authenticator", "sms"]`` - which are the only supported options.
+
+.. py:data:: SECURITY_US_MFA_REQUIRED
+
+    A list of ``US_ENABLED_METHODS`` that will require two-factor
+    authentication. This is of course dependent on the settings of :py:data:`SECURITY_TWO_FACTOR`
+    and :py:data:`SECURITY_TWO_FACTOR_REQUIRED`. Note that even with REQUIRED, only
+    methods listed here will trigger a two-factor cycle.
+
+    Default: ``["password", "email"]``.
 
 .. py:data:: SECURITY_US_TOKEN_VALIDITY
 
@@ -1058,6 +1067,7 @@ The default messages and error levels can be found in ``core.py``.
 * ``SECURITY_MSG_EMAIL_ALREADY_ASSOCIATED``
 * ``SECURITY_MSG_EMAIL_CONFIRMED``
 * ``SECURITY_MSG_EMAIL_NOT_PROVIDED``
+* ``SECURITY_MSG_FAILED_TO_SEND_CODE``
 * ``SECURITY_MSG_FORGOT_PASSWORD``
 * ``SECURITY_MSG_INVALID_CODE``
 * ``SECURITY_MSG_INVALID_CONFIRMATION_TOKEN``

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -92,10 +92,10 @@ register form or override validators::
     security = Security(app, user_datastore,
              register_form=ExtendedRegisterForm)
 
-For the ``register_form`` and ``confirm_register_form``, each field is
-passed to the user model (as kwargs) when a user is created. In the
-above case, the ``first_name`` and ``last_name`` fields are passed
-directly to the model, so the model should look like::
+For the ``register_form`` and ``confirm_register_form``, only fields that
+exist in the user model are passed (as kwargs) to :meth:`.UserDatastore.create_user`.
+Thus, in the above case, the ``first_name`` and ``last_name`` fields will only
+be passed if the model looks like::
 
     class User(db.Model, UserMixin):
         id = db.Column(db.Integer, primary_key=True)

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -140,11 +140,14 @@ SMS or authenticator app). Many large authentication providers already offer thi
 Note that by configuring :py:data:`SECURITY_US_ENABLED_METHODS` an application can
 use this endpoint JUST with identity/password or in fact disallow passwords altogether.
 
+Unified sign in is integrated with two-factor authentication. Since in general
+there is no need for a second factor if the initial authentication was with SMS or
+an authenticator application, the :py:data:`SECURITY_US_MFA_REQUIRED` configuration
+determines which primary authentication mechanisms require a second factor. By default
+limited to ``email`` and ``password`` (if two-factor is enabled).
+
 `Current Limited Functionality`:
 
-    * The Unified signin endpoint does not currently support 2FA. While this isn't really
-      important for SMS and authenticator authentication methods, it would be useful for
-      password and email confirmation methods.
     * Change password does not work if a user registers without a password. However
       forgot-password will allow the user to set a new password.
     * Registration and Confirmation only work with email - so while you can enable multiple

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -88,7 +88,7 @@ If you enable unified sign in by setting your application's :py:data:`SECURITY_U
 configuration value to `True`, your `User` model will require the following
 additional fields:
 
-* ``us_totp_secret``
+* ``us_totp_secrets`` (an arbitrarily long Text field)
 
 If you include 'sms' in :py:data:`SECURITY_US_ENABLED_METHODS`, your `User` model
 will require the following additional field:

--- a/docs/two_factor_configurations.rst
+++ b/docs/two_factor_configurations.rst
@@ -62,13 +62,14 @@ possible using SQLAlchemy:
 
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
 
-    app.config['SECURITY_TWO_FACTOR_ENABLED_METHODS'] = ['mail',
+    app.config['SECURITY_TWO_FACTOR_ENABLED_METHODS'] = ['email',
       'authenticator']  # 'sms' also valid but requires an sms provider
     app.config['SECURITY_TWO_FACTOR'] = True
-    # Generate a good totp secret using: passlib.totp.generate_secret()
-    app.config['SECURITY_TWO_FACTOR_SECRET'] = {"1": "TjQ9Qa31VOrfEzuPy4VHQWPCTmRzCnFzMKLxXYiZu9B"}
     app.config['SECURITY_TWO_FACTOR_RESCUE_MAIL'] = 'put_your_mail@gmail.com'
-    app.config['SECURITY_TWO_FACTOR_URI_SERVICE_NAME'] = 'put_your_app_name'
+
+    # Generate a good totp secret using: passlib.totp.generate_secret()
+    app.config['SECURITY_TOTP_SECRETS'] = {"1": "TjQ9Qa31VOrfEzuPy4VHQWPCTmRzCnFzMKLxXYiZu9B"}
+    app.config['SECURITY_TOTP_ISSUER'] = 'put_your_app_name'
 
     # Create database connection object
     db = SQLAlchemy(app)

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -55,21 +55,23 @@ from .signals import (
     login_instructions_sent,
     password_changed,
     password_reset,
-    us_security_token_sent,
-    us_profile_changed,
     reset_password_instructions_sent,
     tf_code_confirmed,
     tf_profile_changed,
     tf_security_token_sent,
     tf_disabled,
+    user_authenticated,
     user_confirmed,
     user_registered,
+    us_security_token_sent,
+    us_profile_changed,
 )
 from .totp import Totp
 from .unified_signin import (
     UnifiedSigninForm,
     UnifiedSigninSetupForm,
     UnifiedSigninSetupVerifyForm,
+    us_send_security_token,
 )
 from .utils import (
     FsJsonEncoder,

--- a/flask_security/models/fsqla_v2.py
+++ b/flask_security/models/fsqla_v2.py
@@ -13,7 +13,7 @@ This is Version 2:
     - Make username unique (but not required).
 """
 
-from sqlalchemy import Column, String
+from sqlalchemy import Column, String, Text
 from sqlalchemy.ext.declarative import declared_attr
 
 
@@ -39,7 +39,7 @@ class FsUserMixin(FsUserMixinV1):
     username = Column(String(255), unique=True, nullable=True)
 
     # unified sign in
-    us_totp_secret = Column(String(255), nullable=True)
+    us_totp_secrets = Column(Text, nullable=True)
     us_phone_number = Column(String(128), nullable=True)
 
     # This is repeated since I couldn't figure out how to have it reference the

--- a/flask_security/signals.py
+++ b/flask_security/signals.py
@@ -6,12 +6,15 @@
     Flask-Security signals module
 
     :copyright: (c) 2012 by Matt Wright.
+    :copyright: (c) 2019-2020 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 
 import blinker
 
 signals = blinker.Namespace()
+
+user_authenticated = signals.signal("user-authenticated")
 
 user_registered = signals.signal("user-registered")
 
@@ -35,6 +38,6 @@ tf_security_token_sent = signals.signal("tf-security-token-sent")
 
 tf_disabled = signals.signal("tf-disabled")
 
-us_security_token_sent = signals.signal("pl-security-token-sent")
+us_security_token_sent = signals.signal("us-security-token-sent")
 
-us_profile_changed = signals.signal("pl-profile-changed")
+us_profile_changed = signals.signal("us-profile-changed")

--- a/flask_security/templates/security/_menu.html
+++ b/flask_security/templates/security/_menu.html
@@ -7,6 +7,9 @@
   {% if security.unified_signin and not skip_login_menu %}
   <li><a href="{{ url_for_security('us_signin') }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}">{{ _("Unified Sign In") }}</a><br/></li>
   {% endif %}
+  {% if security.unified_signin %}
+      <li><a href="{{ url_for_security('us_setup') }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}">{{ _("Unified Setup") }}</a><br/></li>
+  {% endif %}
   {% if security.registerable %}
   <li><a href="{{ url_for_security('register') }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}">{{ _('Register') }}</a><br/></li>
   {% endif %}

--- a/flask_security/templates/security/two_factor_setup.html
+++ b/flask_security/templates/security/two_factor_setup.html
@@ -14,7 +14,7 @@
         {% endfor %}
         {{ render_field_errors(two_factor_setup_form.setup) }}
         {{ render_field(two_factor_setup_form.submit) }}
-        {% if chosen_method=="mail" and chosen_method in choices %}
+        {% if chosen_method=="email" and chosen_method in choices %}
             <p>{{ _("To complete logging in, please enter the code sent to your mail") }}</p>
         {% endif %}
         {% if chosen_method=="authenticator" and chosen_method in choices %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,7 +231,7 @@ def mongoengine_setup(request, app, tmpdir, realdburl):
 
     class User(db.Document, UserMixin):
         email = db.StringField(unique=True, max_length=255)
-        username = db.StringField(max_length=255)
+        username = db.StringField(unique=True, max_length=255)
         password = db.StringField(required=False, max_length=255)
         security_number = db.IntField(unique=True)
         last_login_at = db.DateTimeField()
@@ -239,7 +239,7 @@ def mongoengine_setup(request, app, tmpdir, realdburl):
         tf_primary_method = db.StringField(max_length=255)
         tf_totp_secret = db.StringField(max_length=255)
         tf_phone_number = db.StringField(max_length=255)
-        us_totp_secret = db.StringField(max_length=255)
+        us_totp_secrets = db.StringField()
         us_phone_number = db.StringField(max_length=255)
         last_login_ip = db.StringField(max_length=100)
         current_login_ip = db.StringField(max_length=100)
@@ -273,10 +273,7 @@ def sqlalchemy_setup(request, app, tmpdir, realdburl):
         db_url, db_info = _setup_realdb(realdburl)
         app.config["SQLALCHEMY_DATABASE_URI"] = db_url
     else:
-        f, path = tempfile.mkstemp(
-            prefix="flask-security-test-db", suffix=".db", dir=str(tmpdir)
-        )
-        app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///" + path
+        app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
 
     db = SQLAlchemy(app)
 
@@ -301,9 +298,6 @@ def sqlalchemy_setup(request, app, tmpdir, realdburl):
         if realdburl:
             db.drop_all()
             _teardown_realdb(db_info)
-        else:
-            os.close(f)
-            os.remove(path)
 
     request.addfinalizer(tear_down)
 
@@ -319,7 +313,7 @@ def sqlalchemy_session_setup(request, app, tmpdir, realdburl):
     from sqlalchemy import create_engine
     from sqlalchemy.orm import scoped_session, sessionmaker, relationship, backref
     from sqlalchemy.ext.declarative import declarative_base
-    from sqlalchemy import Boolean, DateTime, Column, Integer, String, ForeignKey
+    from sqlalchemy import Boolean, DateTime, Column, Integer, String, Text, ForeignKey
 
     f, path = tempfile.mkstemp(
         prefix="flask-security-test-db", suffix=".db", dir=str(tmpdir)
@@ -358,7 +352,7 @@ def sqlalchemy_session_setup(request, app, tmpdir, realdburl):
         tf_primary_method = Column(String(255), nullable=True)
         tf_totp_secret = Column(String(255), nullable=True)
         tf_phone_number = Column(String(255), nullable=True)
-        us_totp_secret = Column(String(255), nullable=True)
+        us_totp_secrets = Column(Text, nullable=True)
         us_phone_number = Column(String(64), nullable=True)
         last_login_ip = Column(String(100))
         current_login_ip = Column(String(100))
@@ -436,7 +430,7 @@ def peewee_setup(request, app, tmpdir, realdburl):
         tf_primary_method = TextField(null=True)
         tf_totp_secret = TextField(null=True)
         tf_phone_number = TextField(null=True)
-        us_totp_secret = TextField(null=True)
+        us_totp_secrets = TextField(null=True)
         us_phone_number = TextField(null=True)
         last_login_ip = TextField(null=True)
         current_login_ip = TextField(null=True)
@@ -500,7 +494,7 @@ def pony_setup(request, app, tmpdir, realdburl):
         tf_primary_method = Optional(str, nullable=True)
         tf_totp_secret = Optional(str, nullable=True)
         tf_phone_number = Optional(str, nullable=True)
-        us_totp_secret = Optional(str, nullable=True)
+        us_totp_secrets = Optional(str, nullable=True)
         us_phone_number = Optional(str, nullable=True)
         last_login_ip = Optional(str)
         current_login_ip = Optional(str)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -85,7 +85,7 @@ def test_fsqla_fields():
     )
     assert attrs == v1_user_attrs
 
-    v2_user_attrs = {"us_totp_secret", "us_phone_number"}
+    v2_user_attrs = {"us_totp_secrets", "us_phone_number"}
     attrs = set(
         [
             a[0]

--- a/tests/test_two_factor.py
+++ b/tests/test_two_factor.py
@@ -75,7 +75,7 @@ def tf_in_session(session):
 def test_two_factor_two_factor_setup_anonymous(app, client, get_message):
 
     # trying to pick method without doing earlier stage
-    data = dict(setup="mail")
+    data = dict(setup="email")
 
     with capture_flashes() as flashes:
         response = client.post("/tf-setup", data=data)
@@ -149,7 +149,7 @@ def test_two_factor_flag(app, client):
         response.jdata["response"]["errors"]["setup"][0] == "Marked method is not valid"
     )
 
-    json_data = '{"setup": "mail"}'
+    json_data = '{"setup": "email"}'
     response = client.post(
         "/tf-setup",
         data=json_data,
@@ -209,7 +209,7 @@ def test_two_factor_flag(app, client):
     assert message in response.data
 
     # change method (from sms to mail)
-    setup_data = dict(setup="mail")
+    setup_data = dict(setup="email")
     testMail = TestMail()
     app.extensions["mail"] = testMail
     response = client.post("/tf-setup", data=setup_data, follow_redirects=True)
@@ -641,8 +641,8 @@ def test_totp_secret_generation(app, client):
     response = client.post(
         "/tf-confirm", data=dict(password=password), follow_redirects=True
     )
-    # Select sms method (regenerates secret)
-    data = dict(setup="sms", phone="+442083661177")
+    # Select sms method but do not send a phone number just yet (regenerates secret)
+    data = dict(setup="sms")
     response = client.post("/tf-setup", data=data, follow_redirects=True)
     assert b"To Which Phone Number Should We Send Code To" in response.data
 
@@ -761,7 +761,7 @@ def test_email_salutation(app, client):
 
     test_mail = TestMail()
     app.extensions["mail"] = test_mail
-    response = client.post("/tf-setup", data=dict(setup="mail"), follow_redirects=True)
+    response = client.post("/tf-setup", data=dict(setup="email"), follow_redirects=True)
     msg = b"To complete logging in, please enter the code sent to your mail"
     assert msg in response.data
 
@@ -778,7 +778,7 @@ def test_username_salutation(app, client):
 
     test_mail = TestMail()
     app.extensions["mail"] = test_mail
-    response = client.post("/tf-setup", data=dict(setup="mail"), follow_redirects=True)
+    response = client.post("/tf-setup", data=dict(setup="email"), follow_redirects=True)
     msg = b"To complete logging in, please enter the code sent to your mail"
     assert msg in response.data
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -214,3 +214,8 @@ class SmsTestSender(SmsSenderBaseClass):
 
     def get_count(self):
         return SmsSenderBaseClass.count
+
+
+class SmsBadSender(SmsSenderBaseClass):
+    def send_sms(self, from_number, to_number, msg):
+        raise ValueError("Unknown number: {}".format(to_number))

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -149,7 +149,7 @@ def create_app():
         )
 
     @us_security_token_sent.connect_via(app)
-    def on_pl_token_sent(myapp, user, token, method, **extra):
+    def on_us_token_sent(myapp, user, token, method, **extra):
         flash(
             "User {} was sent passwordless token {} via {}".format(
                 user.calc_username(), token, method
@@ -217,7 +217,7 @@ Required Models
 
 from flask_security import UserMixin, RoleMixin
 from sqlalchemy.orm import relationship, backref
-from sqlalchemy import Boolean, DateTime, Column, Integer, String, ForeignKey
+from sqlalchemy import Boolean, DateTime, Column, Integer, String, Text, ForeignKey
 
 
 class RolesUsers(Base):
@@ -252,7 +252,7 @@ class User(Base, UserMixin):
     tf_primary_method = Column(String(64))
     tf_totp_secret = Column(String(255))
 
-    us_totp_secret = Column(String(255), nullable=True)
+    us_totp_secrets = Column(Text(), nullable=True)
     us_phone_number = Column(String(128), nullable=True)
 
     roles = relationship(


### PR DESCRIPTION
This factor was larger than expected - with some additional nice results.

US_MFA_REQUIRED is a new configuration variable that will trigger two-factor.

Since in most cases, there isn't any reason to require tfa if already authenticated
with say 'sms' - we track how the user initially authenticated, and use that to
check if tfa is required.
This involved being able to track a 'code' back to a 'method' - which is done
by having a totp_secret PER method, and iterating to find one that verifies.

This prompted adding a new signal - user_authenticated which is invoked upon
successful login and gets the user and authn_via
arguments - this will be useful for auditing. It receives a list so (in the future)
we can audit the entire authentication flow.

Changed the name of a tfa method to "email" rather than "mail" and added backwards
compat code to honor any existing "mail" in the DB.

A recent bug report highlighted that there is no way to catch and manage errors from
send_security_token(). For unified sign in this has been fixed by adding wrapper to UserMixin
that can be overridden.

Fixed a recently introduced bug in tfa setup w.r.t. the new phone number validation.