### PR TITLE
Minor changes for latest werkzeug/Flask-Login packages.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,13 @@ Other changes with possible backwards compatibility issues:
 
 - ``/tf-setup`` never did any phone number validation. Now it does.
 
+Version 3.3.3
+-------------
+
+Released February 11, 2020
+
+Minor changes required to work with latest released Werkzeug and Flask-Login.
+
 Version 3.3.2
 -------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ author = "Matt Wright & Chris Wagner"
 # built documents.
 #
 # The short X.Y version.
-version = "3.3.2"
+version = "3.3.3"
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -428,13 +428,13 @@ in HTTP proxy environment. The following code illustrates a setup
 with a single HTTP proxy in front of the web application::
 
     # At top of file
-    from werkzeug.contrib.fixers import ProxyFix
+    from werkzeug.middleware.proxy_fix import ProxyFix
 
     # After 'Create app'
-    app.wsgi_app = ProxyFix(app.wsgi_app, num_proxies=1)
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1)
 
 To learn more about the ``ProxyFix`` middleware, please see the
-`Werkzeug documentation <https://werkzeug.palletsprojects.com/en/0.15.x/middleware/proxy_fix/#module-werkzeug.middleware.proxy_fix>`_.
+`Werkzeug documentation <https://werkzeug.palletsprojects.com/en/1.0.x/middleware/proxy_fix/#module-werkzeug.middleware.proxy_fix>`_.
 
 .. _unit-testing:
 

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -97,4 +97,4 @@ from .utils import (
     verify_and_update_password,
 )
 
-__version__ = "3.3.2"
+__version__ = "3.3.3"

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -103,7 +103,16 @@ def default_unauthz_handler(func, params):
 
 
 def _check_token():
-    user = _security.login_manager.request_callback(request)
+    # N.B. this isn't great Flask-Login 0.5.0 made this protected
+    # Issue https://github.com/maxcountryman/flask-login/issues/471
+    # was filed to restore public access. We want to call this via
+    # login_manager in case someone has overridden the login_manager which we
+    # allow.
+    if hasattr(_security.login_manager, "request_callback"):
+        # Pre 0.5.0
+        user = _security.login_manager.request_callback(request)
+    else:
+        user = _security.login_manager._request_callback(request)
 
     if user and user.is_authenticated:
         app = current_app._get_current_object()

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ tests_require = [
     "pytest>=3.5.1",
     "sqlalchemy>=1.2.6",
     "sqlalchemy-utils>=0.33.0",
-    "werkzeug>=0.14.1",
+    "werkzeug>=0.15.5",
     "zxcvbn~=4.4.28",
 ]
 
@@ -58,7 +58,7 @@ setup_requires = ["Babel>=1.3", "pytest-runner>=2.6.2", "twine", "wheel"]
 
 install_requires = [
     "Flask>=1.0.2",
-    "Flask-Login>=0.3.0",
+    "Flask-Login>=0.4.1",
     "Flask-Mail>=0.9.1",
     "Flask-Principal>=0.4.0",
     "Flask-WTF>=0.14.2",

--- a/tests/test_trackable.py
+++ b/tests/test_trackable.py
@@ -9,7 +9,7 @@
 import pytest
 from flask import after_this_request, redirect
 from utils import authenticate, logout
-from werkzeug.contrib.fixers import ProxyFix
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from flask_security import login_user
 
@@ -22,7 +22,7 @@ def _client_ip(client):
 
 
 def test_trackable_flag(app, client):
-    app.wsgi_app = ProxyFix(app.wsgi_app, num_proxies=1)
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1)
     e = "matt@lp.com"
     authenticate(client, email=e)
     logout(client)
@@ -38,7 +38,7 @@ def test_trackable_flag(app, client):
 
 
 def test_trackable_with_multiple_ips_in_headers(app, client):
-    app.wsgi_app = ProxyFix(app.wsgi_app, num_proxies=2)
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=2)
 
     e = "matt@lp.com"
     authenticate(client, email=e)
@@ -64,7 +64,7 @@ def test_trackable_using_login_user(app, client):
     datastore.commit() after logging a user in to make sure the trackable
     fields are saved to the datastore.
     """
-    app.wsgi_app = ProxyFix(app.wsgi_app, num_proxies=1)
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1)
 
     @app.route("/login_custom", methods=["POST"])
     def login_custom():


### PR DESCRIPTION
Had a deprecated proxy_fix in a test.

Flask-Login made request_loader protected. As a quick fix,
use the new protected value - filed a bug with Flask-Login to request a public.

Updated a couple of minimum package versions (werkzeug and Flask-Login).