### PR TITLE
Logout form

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -487,6 +487,13 @@ Login/Logout
 
     Default:``security/login_user.html``.
 
+.. py:data:: SECURITY_LOGOUT_USER_TEMPLATE
+
+    Specifies the path to the template for the user logout page. This is valid, when the
+    ``logout_form`` argument is specified for the initializer for the ``Security`` class.
+
+    Default:``security/logout_user.html``.
+
 Registerable
 ------------
 .. py:data:: SECURITY_REGISTERABLE
@@ -828,56 +835,7 @@ Configuration related to the two-factor authentication feature.
 Unified Signin
 --------------
 
-<<<<<<< HEAD
     .. versionadded:: 3.4.0
-=======
-.. tabularcolumns:: |p{6.5cm}|p{8.5cm}|
-
-================================================== =======================================
-``SECURITY_FORGOT_PASSWORD_TEMPLATE``              Specifies the path to the template for
-                                                   the forgot password page. Defaults to
-                                                   ``security/forgot_password.html``.
-``SECURITY_LOGIN_USER_TEMPLATE``                   Specifies the path to the template for
-                                                   the user login page. Defaults to
-                                                   ``security/login_user.html``.
-``SECURITY_LOGOUT_USER_TEMPLATE``                  Specifies the path to the template for
-                                                   the user logout page. This is valid,
-						   when the `logout_form` argument is
-						   specified for the initializer for the
-						   `Security` class. Defaults to
-                                                   ``security/logout_user.html``.
-``SECURITY_REGISTER_USER_TEMPLATE``                Specifies the path to the template for
-                                                   the user registration page. Defaults to
-                                                   ``security/register_user.html``.
-``SECURITY_RESET_PASSWORD_TEMPLATE``               Specifies the path to the template for
-                                                   the reset password page. Defaults to
-                                                   ``security/reset_password.html``.
-``SECURITY_CHANGE_PASSWORD_TEMPLATE``              Specifies the path to the template for
-                                                   the change password page. Defaults to
-                                                   ``security/change_password.html``.
-``SECURITY_SEND_CONFIRMATION_TEMPLATE``            Specifies the path to the template for
-                                                   the resend confirmation instructions
-                                                   page. Defaults to
-                                                   ``security/send_confirmation.html``.
-``SECURITY_SEND_LOGIN_TEMPLATE``                   Specifies the path to the template for
-                                                   the send login instructions page for
-                                                   passwordless logins. Defaults to
-                                                   ``security/send_login.html``.
-``SECURITY_TWO_FACTOR_VERIFY_CODE_TEMPLATE``       Specifies the path to the template for
-                                                   the verify code page for the two-factor
-                                                   authentication process. Defaults to
-                                                   ``security/two_factor_verify_code.html``.
-``SECURITY_TWO_FACTOR_SETUP_TEMPLATE``             Specifies the path to the template for
-                                                   the setup page for the two
-                                                   factor authentication process. Defaults
-                                                   to ``security/two_factor_setup.html``
-``SECURITY_TWO_FACTOR_VERIFY_PASSWORD_TEMPLATE``   Specifies the path to the template for
-                                                   the change method page for the two
-                                                   factor authentication process. Defaults
-                                                   to ``security/two_factor_verify_password.html``.
-
-================================================== =======================================
->>>>>>> c2a3aa5... Update documentation.
 
 .. py:data:: SECURITY_UNIFIED_SIGNIN
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -828,7 +828,56 @@ Configuration related to the two-factor authentication feature.
 Unified Signin
 --------------
 
+<<<<<<< HEAD
     .. versionadded:: 3.4.0
+=======
+.. tabularcolumns:: |p{6.5cm}|p{8.5cm}|
+
+================================================== =======================================
+``SECURITY_FORGOT_PASSWORD_TEMPLATE``              Specifies the path to the template for
+                                                   the forgot password page. Defaults to
+                                                   ``security/forgot_password.html``.
+``SECURITY_LOGIN_USER_TEMPLATE``                   Specifies the path to the template for
+                                                   the user login page. Defaults to
+                                                   ``security/login_user.html``.
+``SECURITY_LOGOUT_USER_TEMPLATE``                  Specifies the path to the template for
+                                                   the user logout page. This is valid,
+						   when the `logout_form` argument is
+						   specified for the initializer for the
+						   `Security` class. Defaults to
+                                                   ``security/logout_user.html``.
+``SECURITY_REGISTER_USER_TEMPLATE``                Specifies the path to the template for
+                                                   the user registration page. Defaults to
+                                                   ``security/register_user.html``.
+``SECURITY_RESET_PASSWORD_TEMPLATE``               Specifies the path to the template for
+                                                   the reset password page. Defaults to
+                                                   ``security/reset_password.html``.
+``SECURITY_CHANGE_PASSWORD_TEMPLATE``              Specifies the path to the template for
+                                                   the change password page. Defaults to
+                                                   ``security/change_password.html``.
+``SECURITY_SEND_CONFIRMATION_TEMPLATE``            Specifies the path to the template for
+                                                   the resend confirmation instructions
+                                                   page. Defaults to
+                                                   ``security/send_confirmation.html``.
+``SECURITY_SEND_LOGIN_TEMPLATE``                   Specifies the path to the template for
+                                                   the send login instructions page for
+                                                   passwordless logins. Defaults to
+                                                   ``security/send_login.html``.
+``SECURITY_TWO_FACTOR_VERIFY_CODE_TEMPLATE``       Specifies the path to the template for
+                                                   the verify code page for the two-factor
+                                                   authentication process. Defaults to
+                                                   ``security/two_factor_verify_code.html``.
+``SECURITY_TWO_FACTOR_SETUP_TEMPLATE``             Specifies the path to the template for
+                                                   the setup page for the two
+                                                   factor authentication process. Defaults
+                                                   to ``security/two_factor_setup.html``
+``SECURITY_TWO_FACTOR_VERIFY_PASSWORD_TEMPLATE``   Specifies the path to the template for
+                                                   the change method page for the two
+                                                   factor authentication process. Defaults
+                                                   to ``security/two_factor_verify_password.html``.
+
+================================================== =======================================
+>>>>>>> c2a3aa5... Update documentation.
 
 .. py:data:: SECURITY_UNIFIED_SIGNIN
 

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -16,6 +16,7 @@ following is a list of view templates:
 
 * `security/forgot_password.html`
 * `security/login_user.html`
+* `security/logout_user.html`
 * `security/register_user.html`
 * `security/reset_password.html`
 * `security/change_password.html`

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -154,6 +154,7 @@ _default_config = {
     "REDIRECT_BEHAVIOR": None,
     "FORGOT_PASSWORD_TEMPLATE": "security/forgot_password.html",
     "LOGIN_USER_TEMPLATE": "security/login_user.html",
+    "LOGOUT_USER_TEMPLATE": "security/logout_user.html",
     "REGISTER_USER_TEMPLATE": "security/register_user.html",
     "RESET_PASSWORD_TEMPLATE": "security/reset_password.html",
     "CHANGE_PASSWORD_TEMPLATE": "security/change_password.html",
@@ -395,6 +396,7 @@ _default_messages = {
 
 _default_forms = {
     "login_form": LoginForm,
+    "logout_form": None,
     "confirm_register_form": ConfirmRegisterForm,
     "register_form": RegisterForm,
     "forgot_password_form": ForgotPasswordForm,
@@ -967,6 +969,9 @@ class Security(object):
     :param datastore: An instance of a user datastore.
     :param register_blueprint: to register the Security blueprint or not.
     :param login_form: set form for the login view
+    :param logout_form: set form for the logout view, if necessary. If set,
+            the endpoint at *SECURITY_LOGOUT_URL* will logout only when a
+            POST request is issued.
     :param register_form: set form for the register view when
             *SECURITY_CONFIRMABLE* is false
     :param confirm_register_form: set form for the register view when

--- a/flask_security/templates/security/logout_user.html
+++ b/flask_security/templates/security/logout_user.html
@@ -1,0 +1,12 @@
+{% extends "security/base.html" %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors %}
+
+{% block content %}
+{% include "security/_messages.html" %}
+<h1>{{ _('Logout') }}</h1>
+<form action="{{ url_for_security('logout') }}" method="POST" name="logout_user_form">
+  {{ logout_user_form.hidden_tag() }}
+  {{ render_field_errors(logout_user_form.csrf_token) }}
+  {{ render_field(logout_user_form.submit) }}
+</form>
+{% endblock %}

--- a/flask_security/translations/ca_ES/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/ca_ES/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 3.1.0\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2019-12-14 21:54-0800\n"
+"POT-Creation-Date: 2020-02-07 19:25+0900\n"
 "PO-Revision-Date: 2019-06-16 00:12+0200\n"
 "Last-Translator: Orestes Sanchez <miceno.atreides@gmail.com>\n"
 "Language: ca_ES\n"
@@ -17,98 +17,98 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: flask_security/core.py:179
+#: flask_security/core.py:180
 msgid "Login Required"
 msgstr "Per poder veure la pàgina sol·licitada és necessari iniciar la sessió"
 
-#: flask_security/core.py:180
+#: flask_security/core.py:181
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 msgid "Welcome"
 msgstr "Benvingut"
 
-#: flask_security/core.py:181
+#: flask_security/core.py:182
 msgid "Please confirm your email"
 msgstr "Si us plau, confirmeu el vostre correu electrònic"
 
-#: flask_security/core.py:182
+#: flask_security/core.py:183
 msgid "Login instructions"
 msgstr "Instruccions d'inici de la sessió"
 
-#: flask_security/core.py:183
+#: flask_security/core.py:184
 #: flask_security/templates/security/email/reset_notice.html:1
 msgid "Your password has been reset"
 msgstr "S'ha restablit la teva contrasenya"
 
-#: flask_security/core.py:184
+#: flask_security/core.py:185
 msgid "Your password has been changed"
 msgstr "S'ha canviat la teva contrasenya"
 
-#: flask_security/core.py:185
+#: flask_security/core.py:186
 msgid "Password reset instructions"
 msgstr "Instruccions de recuperació de la contrasenya"
 
-#: flask_security/core.py:188
+#: flask_security/core.py:189
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:189
+#: flask_security/core.py:190
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:219
+#: flask_security/core.py:220
 msgid "You do not have permission to view this resource."
 msgstr "No tens permís d'accés per a consultar aquest recurs."
 
-#: flask_security/core.py:221
+#: flask_security/core.py:222
 msgid "You are not authenticated. Please supply the correct credentials."
 msgstr ""
 
-#: flask_security/core.py:225
+#: flask_security/core.py:226
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr ""
 "Moltes gràcies. S'ha enviat un correu electrònic a %(email)s amb "
 "instruccions per confirmar el teu compte."
 
-#: flask_security/core.py:228
+#: flask_security/core.py:229
 msgid "Thank you. Your email has been confirmed."
 msgstr "Moltes gràcies. S'ha confirmat el teu correu electrònic."
 
-#: flask_security/core.py:229
+#: flask_security/core.py:230
 msgid "Your email has already been confirmed."
 msgstr "El teu correu electrònic ja s'havia confirmat."
 
-#: flask_security/core.py:230
+#: flask_security/core.py:231
 msgid "Invalid confirmation token."
 msgstr "Token de confirmació no vàlid."
 
-#: flask_security/core.py:232
+#: flask_security/core.py:233
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s ja es associat amb un compte."
 
-#: flask_security/core.py:235
+#: flask_security/core.py:236
 msgid "Password does not match"
 msgstr "La contrasenya no coincideix"
 
-#: flask_security/core.py:236
+#: flask_security/core.py:237
 msgid "Passwords do not match"
 msgstr "Les contrasenyes no coincideixen"
 
-#: flask_security/core.py:237
+#: flask_security/core.py:238
 msgid "Redirections outside the domain are forbidden"
 msgstr "Les redireccions a llocs web externes s'han prohibit"
 
-#: flask_security/core.py:239
+#: flask_security/core.py:240
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
 "Les instruccions per restablir la teva contrasenya s'han enviat a "
 "%(email)s."
 
-#: flask_security/core.py:243
+#: flask_security/core.py:244
 #, python-format
 msgid ""
 "You did not reset your password within %(within)s. New instructions have "
@@ -117,20 +117,20 @@ msgstr ""
 "No vas restablir la teva contrasenya abans de %(within)s. S'han enviat "
 "noves instruccions a %(email)s."
 
-#: flask_security/core.py:249
+#: flask_security/core.py:250
 msgid "Invalid reset password token."
 msgstr "El token per restablir la contrasenya no és vàlid."
 
-#: flask_security/core.py:250
+#: flask_security/core.py:251
 msgid "Email requires confirmation."
 msgstr "El correu electrònic requereix d'una confirmació."
 
-#: flask_security/core.py:252
+#: flask_security/core.py:253
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Les instruccions de confirmació s'han enviat a %(email)s."
 
-#: flask_security/core.py:256
+#: flask_security/core.py:257
 #, python-format
 msgid ""
 "You did not confirm your email within %(within)s. New instructions to "
@@ -139,7 +139,7 @@ msgstr ""
 "No vas confirmar el teu correu electrònic abans de %(within)s. S'han "
 "enviat noves instruccions a %(email)s."
 
-#: flask_security/core.py:264
+#: flask_security/core.py:265
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -148,56 +148,56 @@ msgstr ""
 "No vas iniciar la sessió abans de %(within)s. S'han enviat noves "
 "instruccions a %(email)s."
 
-#: flask_security/core.py:271
+#: flask_security/core.py:272
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "S'han enviat instruccions per l'inici de sessió a %(email)s."
 
-#: flask_security/core.py:274
+#: flask_security/core.py:275
 msgid "Invalid login token."
 msgstr "Token de d'inici de sessió no vàlid."
 
-#: flask_security/core.py:275
+#: flask_security/core.py:276
 msgid "Account is disabled."
 msgstr "el compte està desactivat."
 
-#: flask_security/core.py:276
+#: flask_security/core.py:277
 msgid "Email not provided"
 msgstr "No s'ha inclòs el correu electrònic"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:278
 msgid "Invalid email address"
 msgstr "Adreça de correu electrònic no vàlida"
 
-#: flask_security/core.py:278
+#: flask_security/core.py:279
 msgid "Password not provided"
 msgstr "No s'ha inclòs la contrasenya"
 
-#: flask_security/core.py:279
+#: flask_security/core.py:280
 msgid "No password is set for this user"
 msgstr "No hi ha cap contrasenya per a l'usuari"
 
-#: flask_security/core.py:280
+#: flask_security/core.py:281
 msgid "Password must be at least 6 characters"
 msgstr "La contrasenya ha de tenir al menys 6 caràcters"
 
-#: flask_security/core.py:281
+#: flask_security/core.py:282
 msgid "Specified user does not exist"
 msgstr "L'usuari no existeix"
 
-#: flask_security/core.py:282
+#: flask_security/core.py:283
 msgid "Invalid password"
 msgstr "Contrasenya no vàlida"
 
-#: flask_security/core.py:283
+#: flask_security/core.py:284
 msgid "You have successfully logged in."
 msgstr "La sessió s'ha iniciat amb èxit."
 
-#: flask_security/core.py:284
+#: flask_security/core.py:285
 msgid "Forgot password?"
 msgstr "Has oblidat la teva contrasenya?"
 
-#: flask_security/core.py:286
+#: flask_security/core.py:287
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -205,55 +205,55 @@ msgstr ""
 "Has restablert la teva contrasenya amb èxit i s'ha iniciat la sessió "
 "automàticament."
 
-#: flask_security/core.py:293
+#: flask_security/core.py:294
 msgid "Your new password must be different than your previous password."
 msgstr "La nova contrasenya ha de ser diferent de l'anterior."
 
-#: flask_security/core.py:296
+#: flask_security/core.py:297
 msgid "You successfully changed your password."
 msgstr "La teva contrasenya s'ha modificat amb èxit."
 
-#: flask_security/core.py:297
+#: flask_security/core.py:298
 msgid "Please log in to access this page."
 msgstr "Has d'iniciar sessió per tal d'accedir a aquesta pàgina."
 
-#: flask_security/core.py:298
+#: flask_security/core.py:299
 msgid "Please reauthenticate to access this page."
 msgstr "Has d'iniciar una nova sessió per tal d'accedir a aquesta pàgina."
 
-#: flask_security/core.py:300
+#: flask_security/core.py:301
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:303
+#: flask_security/core.py:304
 msgid "Invalid Token"
 msgstr ""
 
-#: flask_security/core.py:304
+#: flask_security/core.py:305
 msgid "Your token has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:306
+#: flask_security/core.py:307
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:310
+#: flask_security/core.py:311
 msgid "You successfully confirmed password"
 msgstr ""
 
-#: flask_security/core.py:314
+#: flask_security/core.py:315
 msgid "Password confirmation is needed in order to access page"
 msgstr ""
 
-#: flask_security/core.py:318
+#: flask_security/core.py:319
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:321
+#: flask_security/core.py:322
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:323
+#: flask_security/core.py:324
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
@@ -344,6 +344,10 @@ msgstr "Canviar la contrasenya"
 msgid "Send password reset instructions"
 msgstr "Enviar instruccions per restablir la contrasenya"
 
+#: flask_security/templates/security/logout_user.html:6
+msgid "Logout"
+msgstr ""
+
 #: flask_security/templates/security/reset_password.html:6
 msgid "Reset password"
 msgstr "Restablir la contrasenya"
@@ -368,8 +372,8 @@ msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:21
 msgid ""
-"Open your authenticator app on your device and scan the following qrcode "
-"to start receiving codes:"
+"Open Google Authenticator on your device and scan the following qrcode to"
+" start receiving codes:"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:22

--- a/flask_security/translations/da_DK/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/da_DK/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.1.0\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2019-12-14 21:54-0800\n"
+"POT-Creation-Date: 2020-02-07 19:25+0900\n"
 "PO-Revision-Date: 2017-03-23 14:04+0100\n"
 "Last-Translator: Leonhard Printz <leonhardprintz@protonmail.ch>\n"
 "Language: da_DK\n"
@@ -17,96 +17,96 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: flask_security/core.py:179
+#: flask_security/core.py:180
 msgid "Login Required"
 msgstr "Login påkræveet"
 
-#: flask_security/core.py:180
+#: flask_security/core.py:181
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 msgid "Welcome"
 msgstr "Velkommen"
 
-#: flask_security/core.py:181
+#: flask_security/core.py:182
 msgid "Please confirm your email"
 msgstr "Bekræft venligst din email"
 
-#: flask_security/core.py:182
+#: flask_security/core.py:183
 msgid "Login instructions"
 msgstr "Logininstruktioner"
 
-#: flask_security/core.py:183
+#: flask_security/core.py:184
 #: flask_security/templates/security/email/reset_notice.html:1
 msgid "Your password has been reset"
 msgstr "Din adgangskode er blevet nulstillet"
 
-#: flask_security/core.py:184
+#: flask_security/core.py:185
 msgid "Your password has been changed"
 msgstr "Din adgangskode er blevet ændret"
 
-#: flask_security/core.py:185
+#: flask_security/core.py:186
 msgid "Password reset instructions"
 msgstr "Instruktioner til nulstilling af adganskode"
 
-#: flask_security/core.py:188
+#: flask_security/core.py:189
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:189
+#: flask_security/core.py:190
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:219
+#: flask_security/core.py:220
 msgid "You do not have permission to view this resource."
 msgstr "Du har ikke adgang til denne resource."
 
-#: flask_security/core.py:221
+#: flask_security/core.py:222
 msgid "You are not authenticated. Please supply the correct credentials."
 msgstr ""
 
-#: flask_security/core.py:225
+#: flask_security/core.py:226
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Mange tak. Bekræftelsesinstruktioner er blevet sendt til %(email)s."
 
-#: flask_security/core.py:228
+#: flask_security/core.py:229
 msgid "Thank you. Your email has been confirmed."
 msgstr "Mange Tak. Din email er blevet bekræftet."
 
-#: flask_security/core.py:229
+#: flask_security/core.py:230
 msgid "Your email has already been confirmed."
 msgstr "Din email er allerede blevet bekræftet."
 
-#: flask_security/core.py:230
+#: flask_security/core.py:231
 msgid "Invalid confirmation token."
 msgstr "Ugyldig bekræftigelsestoken."
 
-#: flask_security/core.py:232
+#: flask_security/core.py:233
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s er allerede brugt af en anden konto."
 
-#: flask_security/core.py:235
+#: flask_security/core.py:236
 msgid "Password does not match"
 msgstr "Adgangskode passer ikke"
 
-#: flask_security/core.py:236
+#: flask_security/core.py:237
 msgid "Passwords do not match"
 msgstr "Adgangskoderne passer ikke"
 
-#: flask_security/core.py:237
+#: flask_security/core.py:238
 msgid "Redirections outside the domain are forbidden"
 msgstr "Omdirigering udenfor domænet er forbudt"
 
-#: flask_security/core.py:239
+#: flask_security/core.py:240
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
 "Instruktioner til nulstilling af din adgangskode er blevet sendt til "
 "%(email)s."
 
-#: flask_security/core.py:243
+#: flask_security/core.py:244
 #, python-format
 msgid ""
 "You did not reset your password within %(within)s. New instructions have "
@@ -115,20 +115,20 @@ msgstr ""
 "Du har ikke nulstillet din adgangskode indenfor %(within)s. Nye "
 "instruktioner er sendt til %(email)s."
 
-#: flask_security/core.py:249
+#: flask_security/core.py:250
 msgid "Invalid reset password token."
 msgstr "Ugyldig nulstillingstoken."
 
-#: flask_security/core.py:250
+#: flask_security/core.py:251
 msgid "Email requires confirmation."
 msgstr "Email kræver bekræftigelse."
 
-#: flask_security/core.py:252
+#: flask_security/core.py:253
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Bekræftigelsesinstruktioner er blevet sendt til %(email)s."
 
-#: flask_security/core.py:256
+#: flask_security/core.py:257
 #, python-format
 msgid ""
 "You did not confirm your email within %(within)s. New instructions to "
@@ -137,7 +137,7 @@ msgstr ""
 "Du har ikke bekræftet din email indenfor %(within)s. Nye instruktioner er"
 " blevet sendt til %(email)s."
 
-#: flask_security/core.py:264
+#: flask_security/core.py:265
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -146,56 +146,56 @@ msgstr ""
 "Du har ikke logget in indenfor %(within)s. Nye logininstruktioner er "
 "blevet sendt til %(email)s."
 
-#: flask_security/core.py:271
+#: flask_security/core.py:272
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Logininstruktioner er blevet sendt til %(email)s."
 
-#: flask_security/core.py:274
+#: flask_security/core.py:275
 msgid "Invalid login token."
 msgstr "Ugyldig logintoken."
 
-#: flask_security/core.py:275
+#: flask_security/core.py:276
 msgid "Account is disabled."
 msgstr "Kontoen er deaktiveret."
 
-#: flask_security/core.py:276
+#: flask_security/core.py:277
 msgid "Email not provided"
 msgstr "Email ikke angivet"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:278
 msgid "Invalid email address"
 msgstr "Ugyldig email adresse"
 
-#: flask_security/core.py:278
+#: flask_security/core.py:279
 msgid "Password not provided"
 msgstr "Adgangskode ikke angivet"
 
-#: flask_security/core.py:279
+#: flask_security/core.py:280
 msgid "No password is set for this user"
 msgstr "Denne bruger har ingen adganskode"
 
-#: flask_security/core.py:280
+#: flask_security/core.py:281
 msgid "Password must be at least 6 characters"
 msgstr "Adgangskoden skal indeholde mindst 6 tegn"
 
-#: flask_security/core.py:281
+#: flask_security/core.py:282
 msgid "Specified user does not exist"
 msgstr "Denne bruger findes ikke"
 
-#: flask_security/core.py:282
+#: flask_security/core.py:283
 msgid "Invalid password"
 msgstr "Ugyldig adgangskode"
 
-#: flask_security/core.py:283
+#: flask_security/core.py:284
 msgid "You have successfully logged in."
 msgstr "Du er hermed blevet logget ind."
 
-#: flask_security/core.py:284
+#: flask_security/core.py:285
 msgid "Forgot password?"
 msgstr "Glemt adgangskode?"
 
-#: flask_security/core.py:286
+#: flask_security/core.py:287
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -203,55 +203,55 @@ msgstr ""
 "Du har hermed nulstillet din adgangskode og er blevet automatisk logget "
 "ind."
 
-#: flask_security/core.py:293
+#: flask_security/core.py:294
 msgid "Your new password must be different than your previous password."
 msgstr "Din nye adgangskode skal være anderledes end din tidligere adgangskode."
 
-#: flask_security/core.py:296
+#: flask_security/core.py:297
 msgid "You successfully changed your password."
 msgstr "Du har hermed ændret din adgangskode."
 
-#: flask_security/core.py:297
+#: flask_security/core.py:298
 msgid "Please log in to access this page."
 msgstr "Log in for at få adgang til denne side."
 
-#: flask_security/core.py:298
+#: flask_security/core.py:299
 msgid "Please reauthenticate to access this page."
 msgstr "Bekræft identitet for at få adgang til denne side."
 
-#: flask_security/core.py:300
+#: flask_security/core.py:301
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:303
+#: flask_security/core.py:304
 msgid "Invalid Token"
 msgstr ""
 
-#: flask_security/core.py:304
+#: flask_security/core.py:305
 msgid "Your token has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:306
+#: flask_security/core.py:307
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:310
+#: flask_security/core.py:311
 msgid "You successfully confirmed password"
 msgstr ""
 
-#: flask_security/core.py:314
+#: flask_security/core.py:315
 msgid "Password confirmation is needed in order to access page"
 msgstr ""
 
-#: flask_security/core.py:318
+#: flask_security/core.py:319
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:321
+#: flask_security/core.py:322
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:323
+#: flask_security/core.py:324
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
@@ -342,6 +342,10 @@ msgstr "Ændre adgangskode"
 msgid "Send password reset instructions"
 msgstr "Send adgangskode nulstillingsinstruktioner"
 
+#: flask_security/templates/security/logout_user.html:6
+msgid "Logout"
+msgstr ""
+
 #: flask_security/templates/security/reset_password.html:6
 msgid "Reset password"
 msgstr "Nulstil adgangskode"
@@ -366,8 +370,8 @@ msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:21
 msgid ""
-"Open your authenticator app on your device and scan the following qrcode "
-"to start receiving codes:"
+"Open Google Authenticator on your device and scan the following qrcode to"
+" start receiving codes:"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:22

--- a/flask_security/translations/de_DE/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/de_DE/LC_MESSAGES/flask_security.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2019-12-14 21:54-0800\n"
+"POT-Creation-Date: 2020-02-07 19:25+0900\n"
 "PO-Revision-Date: 2017-09-25 09:14+0200\n"
 "Last-Translator: Erich Seifert <dev@erichseifert.de>\n"
 "Language: de_DE\n"
@@ -19,96 +19,96 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: flask_security/core.py:179
+#: flask_security/core.py:180
 msgid "Login Required"
 msgstr "Anmeldung erforderlich"
 
-#: flask_security/core.py:180
+#: flask_security/core.py:181
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 msgid "Welcome"
 msgstr "Willkommen"
 
-#: flask_security/core.py:181
+#: flask_security/core.py:182
 msgid "Please confirm your email"
 msgstr "Bitte E-Mail-Adresse bestätigen"
 
-#: flask_security/core.py:182
+#: flask_security/core.py:183
 msgid "Login instructions"
 msgstr "Anmeldeanleitung"
 
-#: flask_security/core.py:183
+#: flask_security/core.py:184
 #: flask_security/templates/security/email/reset_notice.html:1
 msgid "Your password has been reset"
 msgstr "Das Passwort wurde zurückgesetzt"
 
-#: flask_security/core.py:184
+#: flask_security/core.py:185
 msgid "Your password has been changed"
 msgstr "Das Passwort wurde geändert"
 
-#: flask_security/core.py:185
+#: flask_security/core.py:186
 msgid "Password reset instructions"
 msgstr "Anleitung zur Passwortwiederherstellung"
 
-#: flask_security/core.py:188
+#: flask_security/core.py:189
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:189
+#: flask_security/core.py:190
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:219
+#: flask_security/core.py:220
 msgid "You do not have permission to view this resource."
 msgstr "Keine Berechtigung um diese Ressource zu sehen."
 
-#: flask_security/core.py:221
+#: flask_security/core.py:222
 msgid "You are not authenticated. Please supply the correct credentials."
 msgstr ""
 
-#: flask_security/core.py:225
+#: flask_security/core.py:226
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Vielen Dank. Bestätigungsanleitung wurde an %(email)s gesendet."
 
-#: flask_security/core.py:228
+#: flask_security/core.py:229
 msgid "Thank you. Your email has been confirmed."
 msgstr "Vielen Dank. Die E-Mail-Adresse wurde bestätigt."
 
-#: flask_security/core.py:229
+#: flask_security/core.py:230
 msgid "Your email has already been confirmed."
 msgstr "Die E-Mail-Adresse wurde bereits bestätigt."
 
-#: flask_security/core.py:230
+#: flask_security/core.py:231
 msgid "Invalid confirmation token."
 msgstr "Ungültiger Bestätigungscode."
 
-#: flask_security/core.py:232
+#: flask_security/core.py:233
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s ist bereits mit einem Konto verknüpft."
 
-#: flask_security/core.py:235
+#: flask_security/core.py:236
 msgid "Password does not match"
 msgstr "Das Passwort stimmt nicht überein"
 
-#: flask_security/core.py:236
+#: flask_security/core.py:237
 msgid "Passwords do not match"
 msgstr "Die Passwörter stimmen nicht überein"
 
-#: flask_security/core.py:237
+#: flask_security/core.py:238
 msgid "Redirections outside the domain are forbidden"
 msgstr "Weiterleitungen außerhalb der Domain sind verboten"
 
-#: flask_security/core.py:239
+#: flask_security/core.py:240
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
 "Eine Anleitung, um das Passwort wiederherzustellen wurde an %(email)s "
 "gesendet."
 
-#: flask_security/core.py:243
+#: flask_security/core.py:244
 #, python-format
 msgid ""
 "You did not reset your password within %(within)s. New instructions have "
@@ -117,20 +117,20 @@ msgstr ""
 "Das Passwort wurde nicht innerhalb von %(within)s zurückgesetzt. Eine "
 "neue Anleitung wurde an %(email)s gesendet."
 
-#: flask_security/core.py:249
+#: flask_security/core.py:250
 msgid "Invalid reset password token."
 msgstr "Ungültiger Passwortwiederherstellungscode."
 
-#: flask_security/core.py:250
+#: flask_security/core.py:251
 msgid "Email requires confirmation."
 msgstr "Die E-Mail-Adresse muss bestätigt werden."
 
-#: flask_security/core.py:252
+#: flask_security/core.py:253
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Bestätigungsanleitung wurde an %(email)s gesendet."
 
-#: flask_security/core.py:256
+#: flask_security/core.py:257
 #, python-format
 msgid ""
 "You did not confirm your email within %(within)s. New instructions to "
@@ -139,7 +139,7 @@ msgstr ""
 "Die E-Mail-Adresse wurden nicht innerhalb von %(within)s bestätigt. Neue "
 "Instruktionen wurden an %(email)s gesendet."
 
-#: flask_security/core.py:264
+#: flask_security/core.py:265
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -148,56 +148,56 @@ msgstr ""
 "Die Anmeldung erfolgte nicht in %(within)s. Eine neue Anleitung wurde an "
 "%(email)s gesendet."
 
-#: flask_security/core.py:271
+#: flask_security/core.py:272
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Eine Anleitung zur Anmeldung wurde an %(email)s gesendet."
 
-#: flask_security/core.py:274
+#: flask_security/core.py:275
 msgid "Invalid login token."
 msgstr "Ungültiger Anmeldecode."
 
-#: flask_security/core.py:275
+#: flask_security/core.py:276
 msgid "Account is disabled."
 msgstr "Konto ist deaktiviert."
 
-#: flask_security/core.py:276
+#: flask_security/core.py:277
 msgid "Email not provided"
 msgstr "Keine E-Mail-Adresse angegeben"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:278
 msgid "Invalid email address"
 msgstr "Ungültige E-Mail-Adresse"
 
-#: flask_security/core.py:278
+#: flask_security/core.py:279
 msgid "Password not provided"
 msgstr "Kein Passwort angegeben"
 
-#: flask_security/core.py:279
+#: flask_security/core.py:280
 msgid "No password is set for this user"
 msgstr "Für diesen Benutzer ist kein Passwort gesetzt"
 
-#: flask_security/core.py:280
+#: flask_security/core.py:281
 msgid "Password must be at least 6 characters"
 msgstr "Das Passwort muss mindestens 6 Zeichen lang sein"
 
-#: flask_security/core.py:281
+#: flask_security/core.py:282
 msgid "Specified user does not exist"
 msgstr "Angegebener Benutzer existiert nicht"
 
-#: flask_security/core.py:282
+#: flask_security/core.py:283
 msgid "Invalid password"
 msgstr "Ungültiges Passwort"
 
-#: flask_security/core.py:283
+#: flask_security/core.py:284
 msgid "You have successfully logged in."
 msgstr "Die Anmeldung war erfolgreich."
 
-#: flask_security/core.py:284
+#: flask_security/core.py:285
 msgid "Forgot password?"
 msgstr "Passwort vergessen?"
 
-#: flask_security/core.py:286
+#: flask_security/core.py:287
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -205,55 +205,55 @@ msgstr ""
 "Das Passwort wurde erfolgreich wiederhergestellt und die Anmeldung "
 "erfolgte automatisch."
 
-#: flask_security/core.py:293
+#: flask_security/core.py:294
 msgid "Your new password must be different than your previous password."
 msgstr "Das neue Passwort muss sich vom vorherigen unterscheiden."
 
-#: flask_security/core.py:296
+#: flask_security/core.py:297
 msgid "You successfully changed your password."
 msgstr "Das Passwort wurde erfolgreich geändert."
 
-#: flask_security/core.py:297
+#: flask_security/core.py:298
 msgid "Please log in to access this page."
 msgstr "Bitte anmelden, um diese Seite zu sehen."
 
-#: flask_security/core.py:298
+#: flask_security/core.py:299
 msgid "Please reauthenticate to access this page."
 msgstr "Bitte neu authentifizieren, um auf diese Seite zuzugreifen."
 
-#: flask_security/core.py:300
+#: flask_security/core.py:301
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:303
+#: flask_security/core.py:304
 msgid "Invalid Token"
 msgstr ""
 
-#: flask_security/core.py:304
+#: flask_security/core.py:305
 msgid "Your token has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:306
+#: flask_security/core.py:307
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:310
+#: flask_security/core.py:311
 msgid "You successfully confirmed password"
 msgstr ""
 
-#: flask_security/core.py:314
+#: flask_security/core.py:315
 msgid "Password confirmation is needed in order to access page"
 msgstr ""
 
-#: flask_security/core.py:318
+#: flask_security/core.py:319
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:321
+#: flask_security/core.py:322
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:323
+#: flask_security/core.py:324
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
@@ -344,6 +344,10 @@ msgstr "Passwort ändern"
 msgid "Send password reset instructions"
 msgstr "Anleitung zur Passwortzurücksetzung versenden"
 
+#: flask_security/templates/security/logout_user.html:6
+msgid "Logout"
+msgstr ""
+
 #: flask_security/templates/security/reset_password.html:6
 msgid "Reset password"
 msgstr "Passwort zurücksetzen"
@@ -368,8 +372,8 @@ msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:21
 msgid ""
-"Open your authenticator app on your device and scan the following qrcode "
-"to start receiving codes:"
+"Open Google Authenticator on your device and scan the following qrcode to"
+" start receiving codes:"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:22

--- a/flask_security/translations/es_ES/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/es_ES/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2019-12-14 21:54-0800\n"
+"POT-Creation-Date: 2020-02-07 19:25+0900\n"
 "PO-Revision-Date: 2017-08-25 17:21+0200\n"
 "Last-Translator: Mauko Quiroga <mauko.quiroga@data.gouv.fr>\n"
 "Language: es_ES\n"
@@ -17,98 +17,98 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: flask_security/core.py:179
+#: flask_security/core.py:180
 msgid "Login Required"
 msgstr "Inicio de sesión necesario"
 
-#: flask_security/core.py:180
+#: flask_security/core.py:181
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 msgid "Welcome"
 msgstr "Bienvenido"
 
-#: flask_security/core.py:181
+#: flask_security/core.py:182
 msgid "Please confirm your email"
 msgstr "Por favor, confirma tu correo electrónico"
 
-#: flask_security/core.py:182
+#: flask_security/core.py:183
 msgid "Login instructions"
 msgstr "Instrucciones para iniciar sesión"
 
-#: flask_security/core.py:183
+#: flask_security/core.py:184
 #: flask_security/templates/security/email/reset_notice.html:1
 msgid "Your password has been reset"
 msgstr "Tu contraseña ha sido restablecida"
 
-#: flask_security/core.py:184
+#: flask_security/core.py:185
 msgid "Your password has been changed"
 msgstr "Tu contraseña ha sido cambiada"
 
-#: flask_security/core.py:185
+#: flask_security/core.py:186
 msgid "Password reset instructions"
 msgstr "Instrucciones de recuperación de contraseña"
 
-#: flask_security/core.py:188
+#: flask_security/core.py:189
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:189
+#: flask_security/core.py:190
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:219
+#: flask_security/core.py:220
 msgid "You do not have permission to view this resource."
 msgstr "No tienes permiso para consultar este recurso."
 
-#: flask_security/core.py:221
+#: flask_security/core.py:222
 msgid "You are not authenticated. Please supply the correct credentials."
 msgstr ""
 
-#: flask_security/core.py:225
+#: flask_security/core.py:226
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr ""
 "Gracias. Un correo con instrucciones sobre cómo confirmar tu cuenta ha "
 "sido enviado a %(email)s."
 
-#: flask_security/core.py:228
+#: flask_security/core.py:229
 msgid "Thank you. Your email has been confirmed."
 msgstr "Gracias. Tu correo electrónico ha sido confirmado."
 
-#: flask_security/core.py:229
+#: flask_security/core.py:230
 msgid "Your email has already been confirmed."
 msgstr "Tu correo electrónico ya ha sido confirmado."
 
-#: flask_security/core.py:230
+#: flask_security/core.py:231
 msgid "Invalid confirmation token."
 msgstr "Autentificador de confirmación inválido."
 
-#: flask_security/core.py:232
+#: flask_security/core.py:233
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s ya está asociado a una cuenta."
 
-#: flask_security/core.py:235
+#: flask_security/core.py:236
 msgid "Password does not match"
 msgstr "La contraseña no coincide"
 
-#: flask_security/core.py:236
+#: flask_security/core.py:237
 msgid "Passwords do not match"
 msgstr "Las contraseñas no coinciden"
 
-#: flask_security/core.py:237
+#: flask_security/core.py:238
 msgid "Redirections outside the domain are forbidden"
 msgstr "Las redirecciones a sitios web externos están prohibidas"
 
-#: flask_security/core.py:239
+#: flask_security/core.py:240
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
 "Las instrucciones para restablecer tu contraseña han sido enviadas a "
 "%(email)s."
 
-#: flask_security/core.py:243
+#: flask_security/core.py:244
 #, python-format
 msgid ""
 "You did not reset your password within %(within)s. New instructions have "
@@ -117,20 +117,20 @@ msgstr ""
 "No restableciste tu contraseña antes de %(within)s. Nuevas instrucciones "
 "han sido enviadas a %(email)s."
 
-#: flask_security/core.py:249
+#: flask_security/core.py:250
 msgid "Invalid reset password token."
 msgstr "Autentificador de restablecimiento de contraseña inválido."
 
-#: flask_security/core.py:250
+#: flask_security/core.py:251
 msgid "Email requires confirmation."
 msgstr "El correo electrónico requiere confirmación."
 
-#: flask_security/core.py:252
+#: flask_security/core.py:253
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Las instrucciones de confirmación se han enviado a %(email)s."
 
-#: flask_security/core.py:256
+#: flask_security/core.py:257
 #, python-format
 msgid ""
 "You did not confirm your email within %(within)s. New instructions to "
@@ -140,7 +140,7 @@ msgstr ""
 "instrucciones para confirmar tu correo electrónico han sido enviadas a "
 "%(email)s."
 
-#: flask_security/core.py:264
+#: flask_security/core.py:265
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -149,56 +149,56 @@ msgstr ""
 "No iniciaste sesión antes de %(within)s. Nuevas instrucciones para "
 "iniciar sesión han sido enviadas a %(email)s."
 
-#: flask_security/core.py:271
+#: flask_security/core.py:272
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Instrucciones para iniciar sesión han sido enviadas a %(email)s."
 
-#: flask_security/core.py:274
+#: flask_security/core.py:275
 msgid "Invalid login token."
 msgstr "Autenticador de inicio de sesión inválido."
 
-#: flask_security/core.py:275
+#: flask_security/core.py:276
 msgid "Account is disabled."
 msgstr "Cuenta deshabilitada."
 
-#: flask_security/core.py:276
+#: flask_security/core.py:277
 msgid "Email not provided"
 msgstr "Correo electrónico no indicado"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:278
 msgid "Invalid email address"
 msgstr "Dirección de correo electrónico inválida"
 
-#: flask_security/core.py:278
+#: flask_security/core.py:279
 msgid "Password not provided"
 msgstr "Contraseña no indicada"
 
-#: flask_security/core.py:279
+#: flask_security/core.py:280
 msgid "No password is set for this user"
 msgstr "Ninguna contraseña ha sido definida para este·a usuario·a"
 
-#: flask_security/core.py:280
+#: flask_security/core.py:281
 msgid "Password must be at least 6 characters"
 msgstr "La contraseña debe contar al menos con 6 caracteres"
 
-#: flask_security/core.py:281
+#: flask_security/core.py:282
 msgid "Specified user does not exist"
 msgstr "Usuario·a especificado·a no existe"
 
-#: flask_security/core.py:282
+#: flask_security/core.py:283
 msgid "Invalid password"
 msgstr "Contraseña inválida"
 
-#: flask_security/core.py:283
+#: flask_security/core.py:284
 msgid "You have successfully logged in."
 msgstr "Has iniciado sesión con éxito."
 
-#: flask_security/core.py:284
+#: flask_security/core.py:285
 msgid "Forgot password?"
 msgstr "¿Has olvidado tu contraseña?"
 
-#: flask_security/core.py:286
+#: flask_security/core.py:287
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -206,55 +206,55 @@ msgstr ""
 "Has restablecido tu contraseña con éxito y has iniciado sesión "
 "automáticamente."
 
-#: flask_security/core.py:293
+#: flask_security/core.py:294
 msgid "Your new password must be different than your previous password."
 msgstr "Tu nueva contraseña debe ser diferente de la antigua."
 
-#: flask_security/core.py:296
+#: flask_security/core.py:297
 msgid "You successfully changed your password."
 msgstr "Has cambiado tu contraseña con éxito."
 
-#: flask_security/core.py:297
+#: flask_security/core.py:298
 msgid "Please log in to access this page."
 msgstr "Debes iniciar sesión para poder acceder a esta página."
 
-#: flask_security/core.py:298
+#: flask_security/core.py:299
 msgid "Please reauthenticate to access this page."
 msgstr "Deber iniciar sesión nuevamente para poder acceder a esta página."
 
-#: flask_security/core.py:300
+#: flask_security/core.py:301
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:303
+#: flask_security/core.py:304
 msgid "Invalid Token"
 msgstr ""
 
-#: flask_security/core.py:304
+#: flask_security/core.py:305
 msgid "Your token has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:306
+#: flask_security/core.py:307
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:310
+#: flask_security/core.py:311
 msgid "You successfully confirmed password"
 msgstr ""
 
-#: flask_security/core.py:314
+#: flask_security/core.py:315
 msgid "Password confirmation is needed in order to access page"
 msgstr ""
 
-#: flask_security/core.py:318
+#: flask_security/core.py:319
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:321
+#: flask_security/core.py:322
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:323
+#: flask_security/core.py:324
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
@@ -345,6 +345,10 @@ msgstr "Cambiar la contraseña"
 msgid "Send password reset instructions"
 msgstr "Enviar instrucciones para restablecer la contraseña"
 
+#: flask_security/templates/security/logout_user.html:6
+msgid "Logout"
+msgstr ""
+
 #: flask_security/templates/security/reset_password.html:6
 msgid "Reset password"
 msgstr "Restablecer contraseña"
@@ -369,8 +373,8 @@ msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:21
 msgid ""
-"Open your authenticator app on your device and scan the following qrcode "
-"to start receiving codes:"
+"Open Google Authenticator on your device and scan the following qrcode to"
+" start receiving codes:"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:22

--- a/flask_security/translations/flask_security.pot
+++ b/flask_security/translations/flask_security.pot
@@ -1,246 +1,246 @@
 # Translations template for Flask-Security.
-# Copyright (C) 2019 ORGANIZATION
+# Copyright (C) 2020 ORGANIZATION
 # This file is distributed under the same license as the Flask-Security
 # project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 3.3.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2019-12-14 21:54-0800\n"
+"POT-Creation-Date: 2020-02-07 19:25+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: flask_security/core.py:179
+#: flask_security/core.py:180
 msgid "Login Required"
 msgstr ""
 
-#: flask_security/core.py:180
+#: flask_security/core.py:181
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 msgid "Welcome"
 msgstr ""
 
-#: flask_security/core.py:181
+#: flask_security/core.py:182
 msgid "Please confirm your email"
 msgstr ""
 
-#: flask_security/core.py:182
+#: flask_security/core.py:183
 msgid "Login instructions"
 msgstr ""
 
-#: flask_security/core.py:183
+#: flask_security/core.py:184
 #: flask_security/templates/security/email/reset_notice.html:1
 msgid "Your password has been reset"
 msgstr ""
 
-#: flask_security/core.py:184
+#: flask_security/core.py:185
 msgid "Your password has been changed"
 msgstr ""
 
-#: flask_security/core.py:185
+#: flask_security/core.py:186
 msgid "Password reset instructions"
 msgstr ""
 
-#: flask_security/core.py:188
+#: flask_security/core.py:189
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:189
+#: flask_security/core.py:190
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:219
+#: flask_security/core.py:220
 msgid "You do not have permission to view this resource."
 msgstr ""
 
-#: flask_security/core.py:221
+#: flask_security/core.py:222
 msgid "You are not authenticated. Please supply the correct credentials."
 msgstr ""
 
-#: flask_security/core.py:225
+#: flask_security/core.py:226
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr ""
 
-#: flask_security/core.py:228
+#: flask_security/core.py:229
 msgid "Thank you. Your email has been confirmed."
 msgstr ""
 
-#: flask_security/core.py:229
+#: flask_security/core.py:230
 msgid "Your email has already been confirmed."
 msgstr ""
 
-#: flask_security/core.py:230
+#: flask_security/core.py:231
 msgid "Invalid confirmation token."
 msgstr ""
 
-#: flask_security/core.py:232
+#: flask_security/core.py:233
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr ""
 
-#: flask_security/core.py:235
+#: flask_security/core.py:236
 msgid "Password does not match"
 msgstr ""
 
-#: flask_security/core.py:236
+#: flask_security/core.py:237
 msgid "Passwords do not match"
 msgstr ""
 
-#: flask_security/core.py:237
+#: flask_security/core.py:238
 msgid "Redirections outside the domain are forbidden"
 msgstr ""
 
-#: flask_security/core.py:239
+#: flask_security/core.py:240
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
 
-#: flask_security/core.py:243
+#: flask_security/core.py:244
 #, python-format
 msgid ""
 "You did not reset your password within %(within)s. New instructions have "
 "been sent to %(email)s."
 msgstr ""
 
-#: flask_security/core.py:249
+#: flask_security/core.py:250
 msgid "Invalid reset password token."
 msgstr ""
 
-#: flask_security/core.py:250
+#: flask_security/core.py:251
 msgid "Email requires confirmation."
 msgstr ""
 
-#: flask_security/core.py:252
+#: flask_security/core.py:253
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr ""
 
-#: flask_security/core.py:256
+#: flask_security/core.py:257
 #, python-format
 msgid ""
 "You did not confirm your email within %(within)s. New instructions to "
 "confirm your email have been sent to %(email)s."
 msgstr ""
 
-#: flask_security/core.py:264
+#: flask_security/core.py:265
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
 "sent to %(email)s."
 msgstr ""
 
-#: flask_security/core.py:271
+#: flask_security/core.py:272
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr ""
 
-#: flask_security/core.py:274
+#: flask_security/core.py:275
 msgid "Invalid login token."
 msgstr ""
 
-#: flask_security/core.py:275
+#: flask_security/core.py:276
 msgid "Account is disabled."
 msgstr ""
 
-#: flask_security/core.py:276
+#: flask_security/core.py:277
 msgid "Email not provided"
 msgstr ""
 
-#: flask_security/core.py:277
+#: flask_security/core.py:278
 msgid "Invalid email address"
 msgstr ""
 
-#: flask_security/core.py:278
+#: flask_security/core.py:279
 msgid "Password not provided"
 msgstr ""
 
-#: flask_security/core.py:279
+#: flask_security/core.py:280
 msgid "No password is set for this user"
 msgstr ""
 
-#: flask_security/core.py:280
+#: flask_security/core.py:281
 msgid "Password must be at least 6 characters"
 msgstr ""
 
-#: flask_security/core.py:281
+#: flask_security/core.py:282
 msgid "Specified user does not exist"
 msgstr ""
 
-#: flask_security/core.py:282
+#: flask_security/core.py:283
 msgid "Invalid password"
 msgstr ""
 
-#: flask_security/core.py:283
+#: flask_security/core.py:284
 msgid "You have successfully logged in."
 msgstr ""
 
-#: flask_security/core.py:284
+#: flask_security/core.py:285
 msgid "Forgot password?"
 msgstr ""
 
-#: flask_security/core.py:286
+#: flask_security/core.py:287
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr ""
 
-#: flask_security/core.py:293
+#: flask_security/core.py:294
 msgid "Your new password must be different than your previous password."
 msgstr ""
 
-#: flask_security/core.py:296
+#: flask_security/core.py:297
 msgid "You successfully changed your password."
 msgstr ""
 
-#: flask_security/core.py:297
+#: flask_security/core.py:298
 msgid "Please log in to access this page."
 msgstr ""
 
-#: flask_security/core.py:298
+#: flask_security/core.py:299
 msgid "Please reauthenticate to access this page."
 msgstr ""
 
-#: flask_security/core.py:300
+#: flask_security/core.py:301
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:303
+#: flask_security/core.py:304
 msgid "Invalid Token"
 msgstr ""
 
-#: flask_security/core.py:304
+#: flask_security/core.py:305
 msgid "Your token has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:306
+#: flask_security/core.py:307
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:310
+#: flask_security/core.py:311
 msgid "You successfully confirmed password"
 msgstr ""
 
-#: flask_security/core.py:314
+#: flask_security/core.py:315
 msgid "Password confirmation is needed in order to access page"
 msgstr ""
 
-#: flask_security/core.py:318
+#: flask_security/core.py:319
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:321
+#: flask_security/core.py:322
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:323
+#: flask_security/core.py:324
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
@@ -331,6 +331,10 @@ msgstr ""
 msgid "Send password reset instructions"
 msgstr ""
 
+#: flask_security/templates/security/logout_user.html:6
+msgid "Logout"
+msgstr ""
+
 #: flask_security/templates/security/reset_password.html:6
 msgid "Reset password"
 msgstr ""
@@ -355,8 +359,8 @@ msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:21
 msgid ""
-"Open your authenticator app on your device and scan the following qrcode "
-"to start receiving codes:"
+"Open Google Authenticator on your device and scan the following qrcode to"
+" start receiving codes:"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:22

--- a/flask_security/translations/fr_FR/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/fr_FR/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2019-12-14 21:54-0800\n"
+"POT-Creation-Date: 2020-02-07 19:25+0900\n"
 "PO-Revision-Date: 2017-06-08 10:13+0200\n"
 "Last-Translator: Alexandre Bulté <alexandre@bulte.net>\n"
 "Language: fr_FR\n"
@@ -17,96 +17,96 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: flask_security/core.py:179
+#: flask_security/core.py:180
 msgid "Login Required"
 msgstr "Connexion requise"
 
-#: flask_security/core.py:180
+#: flask_security/core.py:181
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 msgid "Welcome"
 msgstr "Bienvenue"
 
-#: flask_security/core.py:181
+#: flask_security/core.py:182
 msgid "Please confirm your email"
 msgstr "Merci de confirmer votre adresse email"
 
-#: flask_security/core.py:182
+#: flask_security/core.py:183
 msgid "Login instructions"
 msgstr "Instructions de connexion"
 
-#: flask_security/core.py:183
+#: flask_security/core.py:184
 #: flask_security/templates/security/email/reset_notice.html:1
 msgid "Your password has been reset"
 msgstr "Votre mot de passe a été réinitialisé"
 
-#: flask_security/core.py:184
+#: flask_security/core.py:185
 msgid "Your password has been changed"
 msgstr "Votre mot de passe a été changé"
 
-#: flask_security/core.py:185
+#: flask_security/core.py:186
 msgid "Password reset instructions"
 msgstr "Instructions de réinitialisation de votre mot de passe"
 
-#: flask_security/core.py:188
+#: flask_security/core.py:189
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:189
+#: flask_security/core.py:190
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:219
+#: flask_security/core.py:220
 msgid "You do not have permission to view this resource."
 msgstr "Vous n'avez pas l'autorisation d'accéder à cette ressource."
 
-#: flask_security/core.py:221
+#: flask_security/core.py:222
 msgid "You are not authenticated. Please supply the correct credentials."
 msgstr ""
 
-#: flask_security/core.py:225
+#: flask_security/core.py:226
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Merci. Les instructions de confirmation ont été envoyées à %(email)s."
 
-#: flask_security/core.py:228
+#: flask_security/core.py:229
 msgid "Thank you. Your email has been confirmed."
 msgstr "Merci. Votre adresse email a été confirmée."
 
-#: flask_security/core.py:229
+#: flask_security/core.py:230
 msgid "Your email has already been confirmed."
 msgstr "Votre adresse email a déjà été confirmée."
 
-#: flask_security/core.py:230
+#: flask_security/core.py:231
 msgid "Invalid confirmation token."
 msgstr "Token de confirmation non valide."
 
-#: flask_security/core.py:232
+#: flask_security/core.py:233
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "L'adresse %(email)s est déjà utilisée."
 
-#: flask_security/core.py:235
+#: flask_security/core.py:236
 msgid "Password does not match"
 msgstr "Le mot de passe ne correspond pas"
 
-#: flask_security/core.py:236
+#: flask_security/core.py:237
 msgid "Passwords do not match"
 msgstr "Les mots de passe ne correspondent pas"
 
-#: flask_security/core.py:237
+#: flask_security/core.py:238
 msgid "Redirections outside the domain are forbidden"
 msgstr "Les redirections en dehors du domaine sont interdites"
 
-#: flask_security/core.py:239
+#: flask_security/core.py:240
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
 "Les instructions de réinitialisation de votre mot de passe ont été "
 "envoyées à %(email)s."
 
-#: flask_security/core.py:243
+#: flask_security/core.py:244
 #, python-format
 msgid ""
 "You did not reset your password within %(within)s. New instructions have "
@@ -115,20 +115,20 @@ msgstr ""
 "Vous n'avez pas réinitialisé votre mot de passe dans l'intervalle requis "
 "(%(within)s)De nouvelles instructions ont été envoyées à %(email)s."
 
-#: flask_security/core.py:249
+#: flask_security/core.py:250
 msgid "Invalid reset password token."
 msgstr "Token de réinitialisation non valide."
 
-#: flask_security/core.py:250
+#: flask_security/core.py:251
 msgid "Email requires confirmation."
 msgstr "Une confirmation de l'adresse email est requise."
 
-#: flask_security/core.py:252
+#: flask_security/core.py:253
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Les instructions de confirmation ont été envoyées à %(email)s."
 
-#: flask_security/core.py:256
+#: flask_security/core.py:257
 #, python-format
 msgid ""
 "You did not confirm your email within %(within)s. New instructions to "
@@ -137,7 +137,7 @@ msgstr ""
 "Vous n'avez pas confirmé votre adresse email dans l'intervalle requis "
 "(%(within)s)De nouvelles instructions ont été envoyées à %(email)s."
 
-#: flask_security/core.py:264
+#: flask_security/core.py:265
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -146,56 +146,56 @@ msgstr ""
 "Vous ne vous êtes pas connecté dans l'intervalle requis (%(within)s)De "
 "nouvelles instructions ont été envoyées à %(email)s."
 
-#: flask_security/core.py:271
+#: flask_security/core.py:272
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Les instructions de connexion ont été envoyées à %(email)s."
 
-#: flask_security/core.py:274
+#: flask_security/core.py:275
 msgid "Invalid login token."
 msgstr "Token de connexion non valide."
 
-#: flask_security/core.py:275
+#: flask_security/core.py:276
 msgid "Account is disabled."
 msgstr "Le compte est désactivé."
 
-#: flask_security/core.py:276
+#: flask_security/core.py:277
 msgid "Email not provided"
 msgstr "Merci d'indiquer une adresse email"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:278
 msgid "Invalid email address"
 msgstr "Adresse email non valide"
 
-#: flask_security/core.py:278
+#: flask_security/core.py:279
 msgid "Password not provided"
 msgstr "Merci d'indiquer un mot de passe"
 
-#: flask_security/core.py:279
+#: flask_security/core.py:280
 msgid "No password is set for this user"
 msgstr "Cet utilisateur n'a pas de mot de passe"
 
-#: flask_security/core.py:280
+#: flask_security/core.py:281
 msgid "Password must be at least 6 characters"
 msgstr "Le mot de passe doit comporter au moins 6 caractères"
 
-#: flask_security/core.py:281
+#: flask_security/core.py:282
 msgid "Specified user does not exist"
 msgstr "Cet utilisateur n'existe pas"
 
-#: flask_security/core.py:282
+#: flask_security/core.py:283
 msgid "Invalid password"
 msgstr "Mot de passe non valide"
 
-#: flask_security/core.py:283
+#: flask_security/core.py:284
 msgid "You have successfully logged in."
 msgstr "Vous êtes bien connecté."
 
-#: flask_security/core.py:284
+#: flask_security/core.py:285
 msgid "Forgot password?"
 msgstr "Mot de passe oublié&thinsp;?"
 
-#: flask_security/core.py:286
+#: flask_security/core.py:287
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -203,55 +203,55 @@ msgstr ""
 "Vous avez bien réinitialisé votre mot de passe et avez été "
 "automatiquement connecté."
 
-#: flask_security/core.py:293
+#: flask_security/core.py:294
 msgid "Your new password must be different than your previous password."
 msgstr "Votre nouveau mot de passe doit être différent du précédent."
 
-#: flask_security/core.py:296
+#: flask_security/core.py:297
 msgid "You successfully changed your password."
 msgstr "Vous avez bien changé votre mot de passe."
 
-#: flask_security/core.py:297
+#: flask_security/core.py:298
 msgid "Please log in to access this page."
 msgstr "Merci de vous connecter pour accéder à cette page."
 
-#: flask_security/core.py:298
+#: flask_security/core.py:299
 msgid "Please reauthenticate to access this page."
 msgstr "Merci de vous reconnecter pour accéder à cette page."
 
-#: flask_security/core.py:300
+#: flask_security/core.py:301
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:303
+#: flask_security/core.py:304
 msgid "Invalid Token"
 msgstr ""
 
-#: flask_security/core.py:304
+#: flask_security/core.py:305
 msgid "Your token has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:306
+#: flask_security/core.py:307
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:310
+#: flask_security/core.py:311
 msgid "You successfully confirmed password"
 msgstr ""
 
-#: flask_security/core.py:314
+#: flask_security/core.py:315
 msgid "Password confirmation is needed in order to access page"
 msgstr ""
 
-#: flask_security/core.py:318
+#: flask_security/core.py:319
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:321
+#: flask_security/core.py:322
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:323
+#: flask_security/core.py:324
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
@@ -342,6 +342,10 @@ msgstr "Changer de mot de passe"
 msgid "Send password reset instructions"
 msgstr "Envoyer les instructions de réinitialisation de mot de passe"
 
+#: flask_security/templates/security/logout_user.html:6
+msgid "Logout"
+msgstr ""
+
 #: flask_security/templates/security/reset_password.html:6
 msgid "Reset password"
 msgstr "Réinitialiser le mot de passe"
@@ -366,8 +370,8 @@ msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:21
 msgid ""
-"Open your authenticator app on your device and scan the following qrcode "
-"to start receiving codes:"
+"Open Google Authenticator on your device and scan the following qrcode to"
+" start receiving codes:"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:22

--- a/flask_security/translations/ja_JP/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/ja_JP/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2019-12-14 21:54-0800\n"
+"POT-Creation-Date: 2020-02-07 19:25+0900\n"
 "PO-Revision-Date: 2018-01-25 14:12+0900\n"
 "Last-Translator: \n"
 "Language: ja\n"
@@ -17,231 +17,231 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: flask_security/core.py:179
+#: flask_security/core.py:180
 msgid "Login Required"
 msgstr "ログインが必要です"
 
-#: flask_security/core.py:180
+#: flask_security/core.py:181
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 msgid "Welcome"
 msgstr "ようこそ"
 
-#: flask_security/core.py:181
+#: flask_security/core.py:182
 msgid "Please confirm your email"
 msgstr "メール アドレスの検証"
 
-#: flask_security/core.py:182
+#: flask_security/core.py:183
 msgid "Login instructions"
 msgstr "ログイン手順"
 
-#: flask_security/core.py:183
+#: flask_security/core.py:184
 #: flask_security/templates/security/email/reset_notice.html:1
 msgid "Your password has been reset"
 msgstr "パスワード変更"
 
-#: flask_security/core.py:184
+#: flask_security/core.py:185
 msgid "Your password has been changed"
 msgstr "パスワードが変更されました。"
 
-#: flask_security/core.py:185
+#: flask_security/core.py:186
 msgid "Password reset instructions"
 msgstr "パスワード再設定手順"
 
-#: flask_security/core.py:188
+#: flask_security/core.py:189
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:189
+#: flask_security/core.py:190
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:219
+#: flask_security/core.py:220
 msgid "You do not have permission to view this resource."
 msgstr "アクセス権がありません"
 
-#: flask_security/core.py:221
+#: flask_security/core.py:222
 msgid "You are not authenticated. Please supply the correct credentials."
 msgstr ""
 
-#: flask_security/core.py:225
+#: flask_security/core.py:226
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "ご登録ありがとうございます。%(email)sにメール アドレス検証手順が送信されました。"
 
-#: flask_security/core.py:228
+#: flask_security/core.py:229
 msgid "Thank you. Your email has been confirmed."
 msgstr "ありがとうございます。メール アドレスが検証されました。"
 
-#: flask_security/core.py:229
+#: flask_security/core.py:230
 msgid "Your email has already been confirmed."
 msgstr "メール アドレスは検証済みです"
 
-#: flask_security/core.py:230
+#: flask_security/core.py:231
 msgid "Invalid confirmation token."
 msgstr "リンクが無効です"
 
-#: flask_security/core.py:232
+#: flask_security/core.py:233
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s のアカウントは既に作成されています"
 
-#: flask_security/core.py:235
+#: flask_security/core.py:236
 msgid "Password does not match"
 msgstr "パスワードが一致しません"
 
-#: flask_security/core.py:236
+#: flask_security/core.py:237
 msgid "Passwords do not match"
 msgstr "入力したパスワードが一致していません"
 
-#: flask_security/core.py:237
+#: flask_security/core.py:238
 msgid "Redirections outside the domain are forbidden"
 msgstr "ドメイン外へのリダイレクトは禁止されています"
 
-#: flask_security/core.py:239
+#: flask_security/core.py:240
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr "パスワードの再設定手順が %(email)s に送信されました"
 
-#: flask_security/core.py:243
+#: flask_security/core.py:244
 #, python-format
 msgid ""
 "You did not reset your password within %(within)s. New instructions have "
 "been sent to %(email)s."
 msgstr "%(within)s以内にパスワードを設定しませんでした。パスワード再設定手順を %(email)s に再度送信しました。"
 
-#: flask_security/core.py:249
+#: flask_security/core.py:250
 msgid "Invalid reset password token."
 msgstr "リンクが無効です"
 
-#: flask_security/core.py:250
+#: flask_security/core.py:251
 msgid "Email requires confirmation."
 msgstr "メール アドレスの検証が必要です"
 
-#: flask_security/core.py:252
+#: flask_security/core.py:253
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "%(email)sにメール アドレス検証手順が再送信されました"
 
-#: flask_security/core.py:256
+#: flask_security/core.py:257
 #, python-format
 msgid ""
 "You did not confirm your email within %(within)s. New instructions to "
 "confirm your email have been sent to %(email)s."
 msgstr "%(within)s以内にメール アドレスが検証されませんでした。新しい検証手順を %(email)s に送信しました。"
 
-#: flask_security/core.py:264
+#: flask_security/core.py:265
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
 "sent to %(email)s."
 msgstr "%(within)s以内にログインしませんでした。ログイン手順を %(email)s に再度送信しました。"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:272
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "%(email)sにログイン手順が送信されました"
 
-#: flask_security/core.py:274
+#: flask_security/core.py:275
 msgid "Invalid login token."
 msgstr "リンクが無効です"
 
-#: flask_security/core.py:275
+#: flask_security/core.py:276
 msgid "Account is disabled."
 msgstr "アカウントが無効になっています"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:277
 msgid "Email not provided"
 msgstr "メール アドレスを入力してください"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:278
 msgid "Invalid email address"
 msgstr "正しいメール アドレスを入力してください"
 
-#: flask_security/core.py:278
+#: flask_security/core.py:279
 msgid "Password not provided"
 msgstr "パスワードを入力してください"
 
-#: flask_security/core.py:279
+#: flask_security/core.py:280
 msgid "No password is set for this user"
 msgstr "パスワードが設定されていません"
 
-#: flask_security/core.py:280
+#: flask_security/core.py:281
 msgid "Password must be at least 6 characters"
 msgstr "パスワードは6文字以上でなければなりません"
 
-#: flask_security/core.py:281
+#: flask_security/core.py:282
 msgid "Specified user does not exist"
 msgstr "入力を確認してください"
 
-#: flask_security/core.py:282
+#: flask_security/core.py:283
 msgid "Invalid password"
 msgstr "入力を確認してください"
 
-#: flask_security/core.py:283
+#: flask_security/core.py:284
 msgid "You have successfully logged in."
 msgstr "ログインしました"
 
-#: flask_security/core.py:284
+#: flask_security/core.py:285
 msgid "Forgot password?"
 msgstr "パスワードを忘れた場合"
 
-#: flask_security/core.py:286
+#: flask_security/core.py:287
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "パスワードの再設定が完了しました。"
 
-#: flask_security/core.py:293
+#: flask_security/core.py:294
 msgid "Your new password must be different than your previous password."
 msgstr "新旧パスワードが同じです"
 
-#: flask_security/core.py:296
+#: flask_security/core.py:297
 msgid "You successfully changed your password."
 msgstr "パスワードが変更されました"
 
-#: flask_security/core.py:297
+#: flask_security/core.py:298
 msgid "Please log in to access this page."
 msgstr "ログインしてください"
 
-#: flask_security/core.py:298
+#: flask_security/core.py:299
 msgid "Please reauthenticate to access this page."
 msgstr "再度ログインしてください"
 
-#: flask_security/core.py:300
+#: flask_security/core.py:301
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:303
+#: flask_security/core.py:304
 msgid "Invalid Token"
 msgstr ""
 
-#: flask_security/core.py:304
+#: flask_security/core.py:305
 msgid "Your token has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:306
+#: flask_security/core.py:307
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:310
+#: flask_security/core.py:311
 msgid "You successfully confirmed password"
 msgstr ""
 
-#: flask_security/core.py:314
+#: flask_security/core.py:315
 msgid "Password confirmation is needed in order to access page"
 msgstr ""
 
-#: flask_security/core.py:318
+#: flask_security/core.py:319
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:321
+#: flask_security/core.py:322
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:323
+#: flask_security/core.py:324
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
@@ -332,6 +332,10 @@ msgstr "パスワードの変更"
 msgid "Send password reset instructions"
 msgstr "パスワード再設定手順の送信"
 
+#: flask_security/templates/security/logout_user.html:6
+msgid "Logout"
+msgstr "ログアウト"
+
 #: flask_security/templates/security/reset_password.html:6
 msgid "Reset password"
 msgstr "パスワード再設定"
@@ -356,8 +360,8 @@ msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:21
 msgid ""
-"Open your authenticator app on your device and scan the following qrcode "
-"to start receiving codes:"
+"Open Google Authenticator on your device and scan the following qrcode to"
+" start receiving codes:"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:22

--- a/flask_security/translations/nl_NL/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/nl_NL/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2019-12-14 21:54-0800\n"
+"POT-Creation-Date: 2020-02-07 19:25+0900\n"
 "PO-Revision-Date: 2017-05-01 17:52+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: nl_NL\n"
@@ -17,94 +17,94 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: flask_security/core.py:179
+#: flask_security/core.py:180
 msgid "Login Required"
 msgstr "Inloggen Verplicht"
 
-#: flask_security/core.py:180
+#: flask_security/core.py:181
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 msgid "Welcome"
 msgstr "Welkom"
 
-#: flask_security/core.py:181
+#: flask_security/core.py:182
 msgid "Please confirm your email"
 msgstr "Gelieve uw e-mailadres te bevestigen"
 
-#: flask_security/core.py:182
+#: flask_security/core.py:183
 msgid "Login instructions"
 msgstr "Aanmeld instructies"
 
-#: flask_security/core.py:183
+#: flask_security/core.py:184
 #: flask_security/templates/security/email/reset_notice.html:1
 msgid "Your password has been reset"
 msgstr "Uw wachtwoord werd gereset"
 
-#: flask_security/core.py:184
+#: flask_security/core.py:185
 msgid "Your password has been changed"
 msgstr "Uw wachtwoord werd gewijzigd"
 
-#: flask_security/core.py:185
+#: flask_security/core.py:186
 msgid "Password reset instructions"
 msgstr "Wachtwoord reset instructies"
 
-#: flask_security/core.py:188
+#: flask_security/core.py:189
 msgid "Two-factor Login"
 msgstr "Dubbele Authenticatie Aanmelding"
 
-#: flask_security/core.py:189
+#: flask_security/core.py:190
 msgid "Two-factor Rescue"
 msgstr "Dubbele Authenticatie Herstellen"
 
-#: flask_security/core.py:219
+#: flask_security/core.py:220
 msgid "You do not have permission to view this resource."
 msgstr "U heeft niet de nodige rechten om deze pagina te zien."
 
-#: flask_security/core.py:221
+#: flask_security/core.py:222
 msgid "You are not authenticated. Please supply the correct credentials."
 msgstr "U bent niet aangemeld. Voer alstublieft de juiste gegevens in."
 
-#: flask_security/core.py:225
+#: flask_security/core.py:226
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Bedankt. Instructies voor bevestiging zijn verzonden naar %(email)s."
 
-#: flask_security/core.py:228
+#: flask_security/core.py:229
 msgid "Thank you. Your email has been confirmed."
 msgstr "Bedankt. Uw e-mailadres werd bevestigd."
 
-#: flask_security/core.py:229
+#: flask_security/core.py:230
 msgid "Your email has already been confirmed."
 msgstr "Uw e-mailadres werd reeds bevestigd."
 
-#: flask_security/core.py:230
+#: flask_security/core.py:231
 msgid "Invalid confirmation token."
 msgstr "Ongeldige bevestiging token."
 
-#: flask_security/core.py:232
+#: flask_security/core.py:233
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s is al gelinkt aan een ander account."
 
-#: flask_security/core.py:235
+#: flask_security/core.py:236
 msgid "Password does not match"
 msgstr "Wachtwoord komt niet overeen"
 
-#: flask_security/core.py:236
+#: flask_security/core.py:237
 msgid "Passwords do not match"
 msgstr "Wachtwoorden komen niet overeen"
 
-#: flask_security/core.py:237
+#: flask_security/core.py:238
 msgid "Redirections outside the domain are forbidden"
 msgstr "Omleidingen buiten het domein zijn niet toegelaten"
 
-#: flask_security/core.py:239
+#: flask_security/core.py:240
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr "Instructies om uw wachtwoord te resetten werden verzonden naar %(email)s."
 
-#: flask_security/core.py:243
+#: flask_security/core.py:244
 #, python-format
 msgid ""
 "You did not reset your password within %(within)s. New instructions have "
@@ -113,22 +113,22 @@ msgstr ""
 "U heeft uw wachtwoord niet gereset gedurende %(within)s. Nieuwe "
 "instructies werden verzonden naar %(email)s."
 
-#: flask_security/core.py:249
+#: flask_security/core.py:250
 msgid "Invalid reset password token."
 msgstr "Ongeldig wachtwoord reset token."
 
-#: flask_security/core.py:250
+#: flask_security/core.py:251
 msgid "Email requires confirmation."
 msgstr "E-mailadres moet bevestigd worden."
 
-#: flask_security/core.py:252
+#: flask_security/core.py:253
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr ""
 "Instructies ter bevestiging van uw e-mailadres werden verzonden naar "
 "%(email)s."
 
-#: flask_security/core.py:256
+#: flask_security/core.py:257
 #, python-format
 msgid ""
 "You did not confirm your email within %(within)s. New instructions to "
@@ -138,7 +138,7 @@ msgstr ""
 "instructies ter bevestiging van uw e-mailadres werden verzonden naar "
 "%(email)s."
 
-#: flask_security/core.py:264
+#: flask_security/core.py:265
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -147,110 +147,110 @@ msgstr ""
 "Je bent niet ingelogd geweest gedurende %(within)s. Nieuwe instructies om"
 " in te loggen werden verzonden naar%(email)s."
 
-#: flask_security/core.py:271
+#: flask_security/core.py:272
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Instructies om in te loggen werden verzonden naar %(email)s."
 
-#: flask_security/core.py:274
+#: flask_security/core.py:275
 msgid "Invalid login token."
 msgstr "Ongeldige aanmelding."
 
-#: flask_security/core.py:275
+#: flask_security/core.py:276
 msgid "Account is disabled."
 msgstr "Account is geblokkeerd."
 
-#: flask_security/core.py:276
+#: flask_security/core.py:277
 msgid "Email not provided"
 msgstr "Email niet ingevuld"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:278
 msgid "Invalid email address"
 msgstr "Ongeldig e-mailadres"
 
-#: flask_security/core.py:278
+#: flask_security/core.py:279
 msgid "Password not provided"
 msgstr "Wachtwoord niet ingevuld"
 
-#: flask_security/core.py:279
+#: flask_security/core.py:280
 msgid "No password is set for this user"
 msgstr "Er is geen wachtwoord gezet voor deze gebruiker"
 
-#: flask_security/core.py:280
+#: flask_security/core.py:281
 msgid "Password must be at least 6 characters"
 msgstr "Uw wachtwoord moet minstens 6 karakters bevatten"
 
-#: flask_security/core.py:281
+#: flask_security/core.py:282
 msgid "Specified user does not exist"
 msgstr "Deze gebruiker bestaat niet"
 
-#: flask_security/core.py:282
+#: flask_security/core.py:283
 msgid "Invalid password"
 msgstr "Ongeldig wachtwoord"
 
-#: flask_security/core.py:283
+#: flask_security/core.py:284
 msgid "You have successfully logged in."
 msgstr "U bent succesvol ingelogd."
 
-#: flask_security/core.py:284
+#: flask_security/core.py:285
 msgid "Forgot password?"
 msgstr "Wachtwoord vergeten?"
 
-#: flask_security/core.py:286
+#: flask_security/core.py:287
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "U heeft uw wachtwoord succesvol gereset en bent nu automatisch ingelogd."
 
-#: flask_security/core.py:293
+#: flask_security/core.py:294
 msgid "Your new password must be different than your previous password."
 msgstr "Uw nieuw wachtwoord moet verschillend zijn van het voorgaande wachtwoord."
 
-#: flask_security/core.py:296
+#: flask_security/core.py:297
 msgid "You successfully changed your password."
 msgstr "Uw wachtwoord werd met succes gewijzigd."
 
-#: flask_security/core.py:297
+#: flask_security/core.py:298
 msgid "Please log in to access this page."
 msgstr "Gelieve in te loggen om deze pagina te zien."
 
-#: flask_security/core.py:298
+#: flask_security/core.py:299
 msgid "Please reauthenticate to access this page."
 msgstr "Gelieve opnieuw in te loggen om deze pagina te zien."
 
-#: flask_security/core.py:300
+#: flask_security/core.py:301
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:303
+#: flask_security/core.py:304
 msgid "Invalid Token"
 msgstr "Niet valide token"
 
-#: flask_security/core.py:304
+#: flask_security/core.py:305
 msgid "Your token has been confirmed"
 msgstr "Uw token is bevestigd"
 
-#: flask_security/core.py:306
+#: flask_security/core.py:307
 msgid "You successfully changed your two-factor method."
 msgstr "U heeft succesvol uw Dubbele Authenticatie methode veranderd."
 
-#: flask_security/core.py:310
+#: flask_security/core.py:311
 msgid "You successfully confirmed password"
 msgstr "U heeft succesvol uw wachtwoord aangepast"
 
-#: flask_security/core.py:314
+#: flask_security/core.py:315
 msgid "Password confirmation is needed in order to access page"
 msgstr "Wachtwoord bevestiging is nodig voor we deze pagina kunnen laten zien"
 
-#: flask_security/core.py:318
+#: flask_security/core.py:319
 msgid "You currently do not have permissions to access this page"
 msgstr "U heeft niet de juiste permissies om deze pagina te laden"
 
-#: flask_security/core.py:321
+#: flask_security/core.py:322
 msgid "Marked method is not valid"
 msgstr "De gemarkeerde methode is niet valide"
 
-#: flask_security/core.py:323
+#: flask_security/core.py:324
 msgid "You successfully disabled two factor authorization."
 msgstr "U heeft succesvol Dubbele Authenticatie uitgeschakeld."
 
@@ -341,6 +341,10 @@ msgstr "Verander wachtwoord"
 msgid "Send password reset instructions"
 msgstr "Verzend wachtwoord reset instructies"
 
+#: flask_security/templates/security/logout_user.html:6
+msgid "Logout"
+msgstr ""
+
 #: flask_security/templates/security/reset_password.html:6
 msgid "Reset password"
 msgstr "Reset wachtwoord"
@@ -370,10 +374,9 @@ msgstr ""
 "gezonden invoeren"
 
 #: flask_security/templates/security/two_factor_setup.html:21
-#, fuzzy
 msgid ""
-"Open your authenticator app on your device and scan the following qrcode "
-"to start receiving codes:"
+"Open Google Authenticator on your device and scan the following qrcode to"
+" start receiving codes:"
 msgstr ""
 "Open Google Authenticator op uw toestel en scan de volgende qrcode om "
 "codes te kunnen ontvangen:"
@@ -456,4 +459,7 @@ msgstr "kan niet in het e-mail account"
 #: flask_security/templates/security/email/welcome.html:4
 msgid "You can confirm your email through the link below:"
 msgstr "U kan uw e-mailadres bevestigen via de onderstaande link:"
+
+#~ msgid "You can log into your through the link below:"
+#~ msgstr "U kan zich aanmelden via de onderstaande link:"
 

--- a/flask_security/translations/pt_BR/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/pt_BR/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2019-12-14 21:54-0800\n"
+"POT-Creation-Date: 2020-02-07 19:25+0900\n"
 "PO-Revision-Date: 2017-09-27 23:39-0300\n"
 "Last-Translator: José Neto <josenetodino@gmail.com>\n"
 "Language: pt_BR\n"
@@ -17,94 +17,94 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: flask_security/core.py:179
+#: flask_security/core.py:180
 msgid "Login Required"
 msgstr "Login obrigatório"
 
-#: flask_security/core.py:180
+#: flask_security/core.py:181
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 msgid "Welcome"
 msgstr "Bem-vindo"
 
-#: flask_security/core.py:181
+#: flask_security/core.py:182
 msgid "Please confirm your email"
 msgstr "Por favor, confirme seu email"
 
-#: flask_security/core.py:182
+#: flask_security/core.py:183
 msgid "Login instructions"
 msgstr "Instruções de login"
 
-#: flask_security/core.py:183
+#: flask_security/core.py:184
 #: flask_security/templates/security/email/reset_notice.html:1
 msgid "Your password has been reset"
 msgstr "Sua senha foi redefinida"
 
-#: flask_security/core.py:184
+#: flask_security/core.py:185
 msgid "Your password has been changed"
 msgstr "Sua senha foi alterada"
 
-#: flask_security/core.py:185
+#: flask_security/core.py:186
 msgid "Password reset instructions"
 msgstr "Instruções para redfinir a senha"
 
-#: flask_security/core.py:188
+#: flask_security/core.py:189
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:189
+#: flask_security/core.py:190
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:219
+#: flask_security/core.py:220
 msgid "You do not have permission to view this resource."
 msgstr "Você não tem permissão para ver este recurso"
 
-#: flask_security/core.py:221
+#: flask_security/core.py:222
 msgid "You are not authenticated. Please supply the correct credentials."
 msgstr ""
 
-#: flask_security/core.py:225
+#: flask_security/core.py:226
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Obrigado. As instruções para a confirmação foram enviadas para %(email)s."
 
-#: flask_security/core.py:228
+#: flask_security/core.py:229
 msgid "Thank you. Your email has been confirmed."
 msgstr "Obrigado. Seu email foi confirmado."
 
-#: flask_security/core.py:229
+#: flask_security/core.py:230
 msgid "Your email has already been confirmed."
 msgstr "Seu email já foi confirmado."
 
-#: flask_security/core.py:230
+#: flask_security/core.py:231
 msgid "Invalid confirmation token."
 msgstr "Token de confirmação inválido."
 
-#: flask_security/core.py:232
+#: flask_security/core.py:233
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s já está associado a uma conta."
 
-#: flask_security/core.py:235
+#: flask_security/core.py:236
 msgid "Password does not match"
 msgstr "Senha não confere"
 
-#: flask_security/core.py:236
+#: flask_security/core.py:237
 msgid "Passwords do not match"
 msgstr "Senhas não conferem"
 
-#: flask_security/core.py:237
+#: flask_security/core.py:238
 msgid "Redirections outside the domain are forbidden"
 msgstr "Redirecionamentos para fora do domínio são proibidos"
 
-#: flask_security/core.py:239
+#: flask_security/core.py:240
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr "As instruções para redefinir sua senha foram enviadas para %(email)s."
 
-#: flask_security/core.py:243
+#: flask_security/core.py:244
 #, python-format
 msgid ""
 "You did not reset your password within %(within)s. New instructions have "
@@ -113,20 +113,20 @@ msgstr ""
 "Você não redefiniu sua senha dentro de %(within)s. Novas instruções foram"
 " enviadas para %(email)s."
 
-#: flask_security/core.py:249
+#: flask_security/core.py:250
 msgid "Invalid reset password token."
 msgstr "Token de redefinição de senha inválido."
 
-#: flask_security/core.py:250
+#: flask_security/core.py:251
 msgid "Email requires confirmation."
 msgstr "O email requer confirmação."
 
-#: flask_security/core.py:252
+#: flask_security/core.py:253
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "As instruções de confirmaç foram enviadas para %(email)s."
 
-#: flask_security/core.py:256
+#: flask_security/core.py:257
 #, python-format
 msgid ""
 "You did not confirm your email within %(within)s. New instructions to "
@@ -135,7 +135,7 @@ msgstr ""
 "Você não confirmou seu email dentro de %(within)s. Novas instruções foram"
 " enviadas para %(email)s."
 
-#: flask_security/core.py:264
+#: flask_security/core.py:265
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -144,110 +144,110 @@ msgstr ""
 "Você não logou dentro de %(within)s. Novas instruções para logar foram "
 "enviadas para %(email)s."
 
-#: flask_security/core.py:271
+#: flask_security/core.py:272
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Instruções para logar foram enviadas para %(email)s."
 
-#: flask_security/core.py:274
+#: flask_security/core.py:275
 msgid "Invalid login token."
 msgstr "Token de login inválido."
 
-#: flask_security/core.py:275
+#: flask_security/core.py:276
 msgid "Account is disabled."
 msgstr "Conta desabilitada."
 
-#: flask_security/core.py:276
+#: flask_security/core.py:277
 msgid "Email not provided"
 msgstr "Email não informado"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:278
 msgid "Invalid email address"
 msgstr "Endereço de email inválido"
 
-#: flask_security/core.py:278
+#: flask_security/core.py:279
 msgid "Password not provided"
 msgstr "Senha não informada"
 
-#: flask_security/core.py:279
+#: flask_security/core.py:280
 msgid "No password is set for this user"
 msgstr "Nenhuma senha definida para este usuário"
 
-#: flask_security/core.py:280
+#: flask_security/core.py:281
 msgid "Password must be at least 6 characters"
 msgstr "A senha deve ter pelo menos 6 caracteres"
 
-#: flask_security/core.py:281
+#: flask_security/core.py:282
 msgid "Specified user does not exist"
 msgstr "Usuário não existe"
 
-#: flask_security/core.py:282
+#: flask_security/core.py:283
 msgid "Invalid password"
 msgstr "Senha inválida"
 
-#: flask_security/core.py:283
+#: flask_security/core.py:284
 msgid "You have successfully logged in."
 msgstr "Você logou com sucesso."
 
-#: flask_security/core.py:284
+#: flask_security/core.py:285
 msgid "Forgot password?"
 msgstr "Esqueceu a senha?"
 
-#: flask_security/core.py:286
+#: flask_security/core.py:287
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "Você redefiniu sua senha com sucesso e foi logado automaticamente."
 
-#: flask_security/core.py:293
+#: flask_security/core.py:294
 msgid "Your new password must be different than your previous password."
 msgstr "Sua nova senha deve ser diferente da sua senha anterior."
 
-#: flask_security/core.py:296
+#: flask_security/core.py:297
 msgid "You successfully changed your password."
 msgstr "Você alterou sua senha com sucesso."
 
-#: flask_security/core.py:297
+#: flask_security/core.py:298
 msgid "Please log in to access this page."
 msgstr "Por favor, logue para acessar esta página."
 
-#: flask_security/core.py:298
+#: flask_security/core.py:299
 msgid "Please reauthenticate to access this page."
 msgstr "Por favor, reautentique-se para acessar esta página."
 
-#: flask_security/core.py:300
+#: flask_security/core.py:301
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:303
+#: flask_security/core.py:304
 msgid "Invalid Token"
 msgstr ""
 
-#: flask_security/core.py:304
+#: flask_security/core.py:305
 msgid "Your token has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:306
+#: flask_security/core.py:307
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:310
+#: flask_security/core.py:311
 msgid "You successfully confirmed password"
 msgstr ""
 
-#: flask_security/core.py:314
+#: flask_security/core.py:315
 msgid "Password confirmation is needed in order to access page"
 msgstr ""
 
-#: flask_security/core.py:318
+#: flask_security/core.py:319
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:321
+#: flask_security/core.py:322
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:323
+#: flask_security/core.py:324
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
@@ -338,6 +338,10 @@ msgstr "Alterar senha"
 msgid "Send password reset instructions"
 msgstr "Enviar instruções para redefinir a senha"
 
+#: flask_security/templates/security/logout_user.html:6
+msgid "Logout"
+msgstr ""
+
 #: flask_security/templates/security/reset_password.html:6
 msgid "Reset password"
 msgstr "Redefinir senha"
@@ -362,8 +366,8 @@ msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:21
 msgid ""
-"Open your authenticator app on your device and scan the following qrcode "
-"to start receiving codes:"
+"Open Google Authenticator on your device and scan the following qrcode to"
+" start receiving codes:"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:22

--- a/flask_security/translations/pt_PT/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/pt_PT/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2019-12-14 21:54-0800\n"
+"POT-Creation-Date: 2020-02-07 19:25+0900\n"
 "PO-Revision-Date: 2018-04-27 14:00+0100\n"
 "Last-Translator: Micael Grilo <micael.grilo@outlook.com>\n"
 "Language: pt_PT\n"
@@ -17,96 +17,96 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: flask_security/core.py:179
+#: flask_security/core.py:180
 msgid "Login Required"
 msgstr "Login obrigatório"
 
-#: flask_security/core.py:180
+#: flask_security/core.py:181
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 msgid "Welcome"
 msgstr "Bem-vindo"
 
-#: flask_security/core.py:181
+#: flask_security/core.py:182
 msgid "Please confirm your email"
 msgstr "Por favor, confirme o seu email"
 
-#: flask_security/core.py:182
+#: flask_security/core.py:183
 msgid "Login instructions"
 msgstr "Instruções de login"
 
-#: flask_security/core.py:183
+#: flask_security/core.py:184
 #: flask_security/templates/security/email/reset_notice.html:1
 msgid "Your password has been reset"
 msgstr "A sua palavra-passe foi redefinida"
 
-#: flask_security/core.py:184
+#: flask_security/core.py:185
 msgid "Your password has been changed"
 msgstr "A sua palavra-passe foi alterada"
 
-#: flask_security/core.py:185
+#: flask_security/core.py:186
 msgid "Password reset instructions"
 msgstr "Instruções para redefinir a palavra-passe"
 
-#: flask_security/core.py:188
+#: flask_security/core.py:189
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:189
+#: flask_security/core.py:190
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:219
+#: flask_security/core.py:220
 msgid "You do not have permission to view this resource."
 msgstr "Não tem permissões para ver este recurso"
 
-#: flask_security/core.py:221
+#: flask_security/core.py:222
 msgid "You are not authenticated. Please supply the correct credentials."
 msgstr ""
 
-#: flask_security/core.py:225
+#: flask_security/core.py:226
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Obrigado. As instruções para a confirmação foram enviadas para %(email)s."
 
-#: flask_security/core.py:228
+#: flask_security/core.py:229
 msgid "Thank you. Your email has been confirmed."
 msgstr "Obrigado. O seu email foi confirmado."
 
-#: flask_security/core.py:229
+#: flask_security/core.py:230
 msgid "Your email has already been confirmed."
 msgstr "O seu email já foi confirmado."
 
-#: flask_security/core.py:230
+#: flask_security/core.py:231
 msgid "Invalid confirmation token."
 msgstr "Token de confirmação inválido."
 
-#: flask_security/core.py:232
+#: flask_security/core.py:233
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s já está associado a uma conta."
 
-#: flask_security/core.py:235
+#: flask_security/core.py:236
 msgid "Password does not match"
 msgstr "Palavra-passe não coincide"
 
-#: flask_security/core.py:236
+#: flask_security/core.py:237
 msgid "Passwords do not match"
 msgstr "Palavras-passe não coincidem"
 
-#: flask_security/core.py:237
+#: flask_security/core.py:238
 msgid "Redirections outside the domain are forbidden"
 msgstr "Redirecionamentos para fora do domínio são proibidos"
 
-#: flask_security/core.py:239
+#: flask_security/core.py:240
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
 "As instruções para redefinir a sua palavra-passe foram enviadas para "
 "%(email)s."
 
-#: flask_security/core.py:243
+#: flask_security/core.py:244
 #, python-format
 msgid ""
 "You did not reset your password within %(within)s. New instructions have "
@@ -115,20 +115,20 @@ msgstr ""
 "Não redefiniu a sua palavra-passe dentro de %(within)s. Novas instruções "
 "foram enviadas para %(email)s."
 
-#: flask_security/core.py:249
+#: flask_security/core.py:250
 msgid "Invalid reset password token."
 msgstr "Token de redefinição de senha inválido."
 
-#: flask_security/core.py:250
+#: flask_security/core.py:251
 msgid "Email requires confirmation."
 msgstr "O email requer confirmação."
 
-#: flask_security/core.py:252
+#: flask_security/core.py:253
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "As instruções de confirmação foram enviadas para %(email)s."
 
-#: flask_security/core.py:256
+#: flask_security/core.py:257
 #, python-format
 msgid ""
 "You did not confirm your email within %(within)s. New instructions to "
@@ -137,7 +137,7 @@ msgstr ""
 "Não confirmou o seu email dentro de %(within)s. Novas instruções foram "
 "enviadas para %(email)s."
 
-#: flask_security/core.py:264
+#: flask_security/core.py:265
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -146,56 +146,56 @@ msgstr ""
 "Não iniciou sessão dentro de %(within)s. Novas instruções de inicio de "
 "sessão foram enviadas para %(email)s."
 
-#: flask_security/core.py:271
+#: flask_security/core.py:272
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Instruções para o inicio de sessão foram enviadas para %(email)s."
 
-#: flask_security/core.py:274
+#: flask_security/core.py:275
 msgid "Invalid login token."
 msgstr "Token de login inválido."
 
-#: flask_security/core.py:275
+#: flask_security/core.py:276
 msgid "Account is disabled."
 msgstr "Conta desactivada."
 
-#: flask_security/core.py:276
+#: flask_security/core.py:277
 msgid "Email not provided"
 msgstr "Email em falta"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:278
 msgid "Invalid email address"
 msgstr "Endereço de email inválido"
 
-#: flask_security/core.py:278
+#: flask_security/core.py:279
 msgid "Password not provided"
 msgstr "Palavra-passe em falta"
 
-#: flask_security/core.py:279
+#: flask_security/core.py:280
 msgid "No password is set for this user"
 msgstr "Nenhuma palavra-passe foi definida para este utilizador"
 
-#: flask_security/core.py:280
+#: flask_security/core.py:281
 msgid "Password must be at least 6 characters"
 msgstr "A palavra-passe deve ter pelo menos 6 caracteres"
 
-#: flask_security/core.py:281
+#: flask_security/core.py:282
 msgid "Specified user does not exist"
 msgstr "Utilizador não existe"
 
-#: flask_security/core.py:282
+#: flask_security/core.py:283
 msgid "Invalid password"
 msgstr "Palavra-passe inválida"
 
-#: flask_security/core.py:283
+#: flask_security/core.py:284
 msgid "You have successfully logged in."
 msgstr "Sessão iniciada com sucesso."
 
-#: flask_security/core.py:284
+#: flask_security/core.py:285
 msgid "Forgot password?"
 msgstr "Esqueceu a palavra-passe?"
 
-#: flask_security/core.py:286
+#: flask_security/core.py:287
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -203,55 +203,55 @@ msgstr ""
 "Redefiniu a sua palavra-passe com sucesso e iniciou sessão "
 "automaticamente."
 
-#: flask_security/core.py:293
+#: flask_security/core.py:294
 msgid "Your new password must be different than your previous password."
 msgstr "A sua nova palavra-passe deve ser diferente da anterior."
 
-#: flask_security/core.py:296
+#: flask_security/core.py:297
 msgid "You successfully changed your password."
 msgstr "Alterou a sua palavra-passe com sucesso."
 
-#: flask_security/core.py:297
+#: flask_security/core.py:298
 msgid "Please log in to access this page."
 msgstr "Por favor, inicie sessão para aceder a esta página."
 
-#: flask_security/core.py:298
+#: flask_security/core.py:299
 msgid "Please reauthenticate to access this page."
 msgstr "Por favor, reautentique-se para aceder esta página."
 
-#: flask_security/core.py:300
+#: flask_security/core.py:301
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:303
+#: flask_security/core.py:304
 msgid "Invalid Token"
 msgstr ""
 
-#: flask_security/core.py:304
+#: flask_security/core.py:305
 msgid "Your token has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:306
+#: flask_security/core.py:307
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:310
+#: flask_security/core.py:311
 msgid "You successfully confirmed password"
 msgstr ""
 
-#: flask_security/core.py:314
+#: flask_security/core.py:315
 msgid "Password confirmation is needed in order to access page"
 msgstr ""
 
-#: flask_security/core.py:318
+#: flask_security/core.py:319
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:321
+#: flask_security/core.py:322
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:323
+#: flask_security/core.py:324
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
@@ -342,6 +342,10 @@ msgstr "Alterar palavra-passe"
 msgid "Send password reset instructions"
 msgstr "Enviar instruções para redefinir a palavra-passe"
 
+#: flask_security/templates/security/logout_user.html:6
+msgid "Logout"
+msgstr ""
+
 #: flask_security/templates/security/reset_password.html:6
 msgid "Reset password"
 msgstr "Redefinir palavra-passe"
@@ -366,8 +370,8 @@ msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:21
 msgid ""
-"Open your authenticator app on your device and scan the following qrcode "
-"to start receiving codes:"
+"Open Google Authenticator on your device and scan the following qrcode to"
+" start receiving codes:"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:22

--- a/flask_security/translations/ru_RU/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/ru_RU/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2019-12-14 21:54-0800\n"
+"POT-Creation-Date: 2020-02-07 19:25+0900\n"
 "PO-Revision-Date: 2017-04-15 15:15+0300\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ru_RU\n"
@@ -18,94 +18,94 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: flask_security/core.py:179
+#: flask_security/core.py:180
 msgid "Login Required"
 msgstr "Требуется авторизация"
 
-#: flask_security/core.py:180
+#: flask_security/core.py:181
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 msgid "Welcome"
 msgstr "Добро пожаловать"
 
-#: flask_security/core.py:181
+#: flask_security/core.py:182
 msgid "Please confirm your email"
 msgstr "Пожалуйста, подтвердите свой почтовый адрес"
 
-#: flask_security/core.py:182
+#: flask_security/core.py:183
 msgid "Login instructions"
 msgstr "Инструкция по входу"
 
-#: flask_security/core.py:183
+#: flask_security/core.py:184
 #: flask_security/templates/security/email/reset_notice.html:1
 msgid "Your password has been reset"
 msgstr "Ваш пароль был сброшен"
 
-#: flask_security/core.py:184
+#: flask_security/core.py:185
 msgid "Your password has been changed"
 msgstr "Ваш пароль был изменён"
 
-#: flask_security/core.py:185
+#: flask_security/core.py:186
 msgid "Password reset instructions"
 msgstr "Инструкция по восстановлению пароля"
 
-#: flask_security/core.py:188
+#: flask_security/core.py:189
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:189
+#: flask_security/core.py:190
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:219
+#: flask_security/core.py:220
 msgid "You do not have permission to view this resource."
 msgstr "У вас нет прав доступа к этому ресурсу."
 
-#: flask_security/core.py:221
+#: flask_security/core.py:222
 msgid "You are not authenticated. Please supply the correct credentials."
 msgstr ""
 
-#: flask_security/core.py:225
+#: flask_security/core.py:226
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Спасибо. Инструкция по подтверждению аккаунта отправлена на %(email)s."
 
-#: flask_security/core.py:228
+#: flask_security/core.py:229
 msgid "Thank you. Your email has been confirmed."
 msgstr "Спасибо. Ваш почтовый адрес был подтверждён."
 
-#: flask_security/core.py:229
+#: flask_security/core.py:230
 msgid "Your email has already been confirmed."
 msgstr "Ваш почтовый адрес уже подтверждён."
 
-#: flask_security/core.py:230
+#: flask_security/core.py:231
 msgid "Invalid confirmation token."
 msgstr "Неверный токен для подтверждения аккаунта."
 
-#: flask_security/core.py:232
+#: flask_security/core.py:233
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s уже привязан к другому аккаунту."
 
-#: flask_security/core.py:235
+#: flask_security/core.py:236
 msgid "Password does not match"
 msgstr "Пароль не подходит"
 
-#: flask_security/core.py:236
+#: flask_security/core.py:237
 msgid "Passwords do not match"
 msgstr "Пароли не совпадают"
 
-#: flask_security/core.py:237
+#: flask_security/core.py:238
 msgid "Redirections outside the domain are forbidden"
 msgstr "Перенаправления вне текущего домена запрещены"
 
-#: flask_security/core.py:239
+#: flask_security/core.py:240
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr "Инструкция по восстановлению пароля отправлена на %(email)s."
 
-#: flask_security/core.py:243
+#: flask_security/core.py:244
 #, python-format
 msgid ""
 "You did not reset your password within %(within)s. New instructions have "
@@ -114,20 +114,20 @@ msgstr ""
 "Вы не восстановили пароль в течение %(within)s. Новая инструкция "
 "отправлена на %(email)s."
 
-#: flask_security/core.py:249
+#: flask_security/core.py:250
 msgid "Invalid reset password token."
 msgstr "Неверный токен для восстановления пароля."
 
-#: flask_security/core.py:250
+#: flask_security/core.py:251
 msgid "Email requires confirmation."
 msgstr "Почтовый адрес требует подтверждения."
 
-#: flask_security/core.py:252
+#: flask_security/core.py:253
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Инструкция по подтверждению аккаунта отправлена на %(email)s."
 
-#: flask_security/core.py:256
+#: flask_security/core.py:257
 #, python-format
 msgid ""
 "You did not confirm your email within %(within)s. New instructions to "
@@ -136,7 +136,7 @@ msgstr ""
 "Вы не подтвердили свой почтовый адрес в течение %(within)s. Новая "
 "инструкция по подтверждению отправлена на %(email)s."
 
-#: flask_security/core.py:264
+#: flask_security/core.py:265
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -145,110 +145,110 @@ msgstr ""
 "Вы не вошли в течение %(within)s. Новая инструкция по входу отправлена на"
 " %(email)s."
 
-#: flask_security/core.py:271
+#: flask_security/core.py:272
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Инструкция по входу отправлена на %(email)s."
 
-#: flask_security/core.py:274
+#: flask_security/core.py:275
 msgid "Invalid login token."
 msgstr "Неверный токен для входа."
 
-#: flask_security/core.py:275
+#: flask_security/core.py:276
 msgid "Account is disabled."
 msgstr "Аккаунт отключён."
 
-#: flask_security/core.py:276
+#: flask_security/core.py:277
 msgid "Email not provided"
 msgstr "Почтовый адрес не введён"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:278
 msgid "Invalid email address"
 msgstr "Неверный почтовый адрес"
 
-#: flask_security/core.py:278
+#: flask_security/core.py:279
 msgid "Password not provided"
 msgstr "Пароль не введён"
 
-#: flask_security/core.py:279
+#: flask_security/core.py:280
 msgid "No password is set for this user"
 msgstr "У данного пользователя не установлен пароль"
 
-#: flask_security/core.py:280
+#: flask_security/core.py:281
 msgid "Password must be at least 6 characters"
 msgstr "Пароль должен содержать как минимум 6 символов"
 
-#: flask_security/core.py:281
+#: flask_security/core.py:282
 msgid "Specified user does not exist"
 msgstr "Данный пользователь не найден"
 
-#: flask_security/core.py:282
+#: flask_security/core.py:283
 msgid "Invalid password"
 msgstr "Неверный пароль"
 
-#: flask_security/core.py:283
+#: flask_security/core.py:284
 msgid "You have successfully logged in."
 msgstr "Вы вошли."
 
-#: flask_security/core.py:284
+#: flask_security/core.py:285
 msgid "Forgot password?"
 msgstr "Забыли пароль?"
 
-#: flask_security/core.py:286
+#: flask_security/core.py:287
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "Ваш пароль был восстановлен и вы автоматически вошли."
 
-#: flask_security/core.py:293
+#: flask_security/core.py:294
 msgid "Your new password must be different than your previous password."
 msgstr "Ваш новый пароль должен отличаться от предыдущего."
 
-#: flask_security/core.py:296
+#: flask_security/core.py:297
 msgid "You successfully changed your password."
 msgstr "Вы удачно сменили пароль."
 
-#: flask_security/core.py:297
+#: flask_security/core.py:298
 msgid "Please log in to access this page."
 msgstr "Пожалуйста, войдите чтобы получить доступ к этой странице."
 
-#: flask_security/core.py:298
+#: flask_security/core.py:299
 msgid "Please reauthenticate to access this page."
 msgstr "Пожалуйста, войдите заново чтобы получить доступ к этой странице."
 
-#: flask_security/core.py:300
+#: flask_security/core.py:301
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:303
+#: flask_security/core.py:304
 msgid "Invalid Token"
 msgstr ""
 
-#: flask_security/core.py:304
+#: flask_security/core.py:305
 msgid "Your token has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:306
+#: flask_security/core.py:307
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:310
+#: flask_security/core.py:311
 msgid "You successfully confirmed password"
 msgstr ""
 
-#: flask_security/core.py:314
+#: flask_security/core.py:315
 msgid "Password confirmation is needed in order to access page"
 msgstr ""
 
-#: flask_security/core.py:318
+#: flask_security/core.py:319
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:321
+#: flask_security/core.py:322
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:323
+#: flask_security/core.py:324
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
@@ -339,6 +339,10 @@ msgstr "Сменить пароль"
 msgid "Send password reset instructions"
 msgstr "Отправить инструкцию по сбросу пароля"
 
+#: flask_security/templates/security/logout_user.html:6
+msgid "Logout"
+msgstr ""
+
 #: flask_security/templates/security/reset_password.html:6
 msgid "Reset password"
 msgstr "Сбросить пароль"
@@ -363,8 +367,8 @@ msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:21
 msgid ""
-"Open your authenticator app on your device and scan the following qrcode "
-"to start receiving codes:"
+"Open Google Authenticator on your device and scan the following qrcode to"
+" start receiving codes:"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:22

--- a/flask_security/translations/tr_TR/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/tr_TR/LC_MESSAGES/flask_security.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2019-12-14 21:54-0800\n"
+"POT-Creation-Date: 2020-02-07 19:25+0900\n"
 "PO-Revision-Date: 2018-12-20 18:48+0300\n"
 "Last-Translator: Ecmel B. Canlıer <me@ecmelberk.com>\n"
 "Language: tr_TR\n"
@@ -16,94 +16,94 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: flask_security/core.py:179
+#: flask_security/core.py:180
 msgid "Login Required"
 msgstr "Giriş yapmanız gerekmektedir"
 
-#: flask_security/core.py:180
+#: flask_security/core.py:181
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 msgid "Welcome"
 msgstr "Hoş Geldiniz"
 
-#: flask_security/core.py:181
+#: flask_security/core.py:182
 msgid "Please confirm your email"
 msgstr "Lütfen e-posta adresinizi onaylayın"
 
-#: flask_security/core.py:182
+#: flask_security/core.py:183
 msgid "Login instructions"
 msgstr "Giriş talimatları"
 
-#: flask_security/core.py:183
+#: flask_security/core.py:184
 #: flask_security/templates/security/email/reset_notice.html:1
 msgid "Your password has been reset"
 msgstr "Şifreniz yenilenmiştir"
 
-#: flask_security/core.py:184
+#: flask_security/core.py:185
 msgid "Your password has been changed"
 msgstr "Şifreniz değiştirilmiştir"
 
-#: flask_security/core.py:185
+#: flask_security/core.py:186
 msgid "Password reset instructions"
 msgstr "Şifre yenileme talimatları"
 
-#: flask_security/core.py:188
+#: flask_security/core.py:189
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:189
+#: flask_security/core.py:190
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:219
+#: flask_security/core.py:220
 msgid "You do not have permission to view this resource."
 msgstr "Bu maddeyi görmeye yetkiniz yoktur."
 
-#: flask_security/core.py:221
+#: flask_security/core.py:222
 msgid "You are not authenticated. Please supply the correct credentials."
 msgstr ""
 
-#: flask_security/core.py:225
+#: flask_security/core.py:226
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Teşekkür ederiz. Onaylama talimatları %(email)s adresine gönderilmiştir."
 
-#: flask_security/core.py:228
+#: flask_security/core.py:229
 msgid "Thank you. Your email has been confirmed."
 msgstr "Teşekkür ederiz. E-posta adresiniz onaylanmıştır"
 
-#: flask_security/core.py:229
+#: flask_security/core.py:230
 msgid "Your email has already been confirmed."
 msgstr "E-posta adresiniz zaten onaylanmış."
 
-#: flask_security/core.py:230
+#: flask_security/core.py:231
 msgid "Invalid confirmation token."
 msgstr "Yanlış onaylama kodu."
 
-#: flask_security/core.py:232
+#: flask_security/core.py:233
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s başka bir hesaba bağlı."
 
-#: flask_security/core.py:235
+#: flask_security/core.py:236
 msgid "Password does not match"
 msgstr "Şifre yanlış"
 
-#: flask_security/core.py:236
+#: flask_security/core.py:237
 msgid "Passwords do not match"
 msgstr "Şifreler uymuyor"
 
-#: flask_security/core.py:237
+#: flask_security/core.py:238
 msgid "Redirections outside the domain are forbidden"
 msgstr "Adres dışına yönlendirmeler yasaktır"
 
-#: flask_security/core.py:239
+#: flask_security/core.py:240
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr "Şifrenizi yenileme talimatları %(email)s adresine gönderilmiştir."
 
-#: flask_security/core.py:243
+#: flask_security/core.py:244
 #, python-format
 msgid ""
 "You did not reset your password within %(within)s. New instructions have "
@@ -112,20 +112,20 @@ msgstr ""
 "Şifrenizi %(within)s içinde yenilemediniz. Yeni talimatlar %(email)s "
 "adresine gönderilmiştir."
 
-#: flask_security/core.py:249
+#: flask_security/core.py:250
 msgid "Invalid reset password token."
 msgstr "Yanlış şifre yenileme kodu."
 
-#: flask_security/core.py:250
+#: flask_security/core.py:251
 msgid "Email requires confirmation."
 msgstr "E-posta onayı gerekmektedir."
 
-#: flask_security/core.py:252
+#: flask_security/core.py:253
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Onaylama talimatları %(email)s adresine gönderilmiştir."
 
-#: flask_security/core.py:256
+#: flask_security/core.py:257
 #, python-format
 msgid ""
 "You did not confirm your email within %(within)s. New instructions to "
@@ -134,7 +134,7 @@ msgstr ""
 "E-posta adresinizi %(within)s içinde onaylamadınız. Yeni onaylama "
 "talimatları %(email)s adresine gönderilmiştir."
 
-#: flask_security/core.py:264
+#: flask_security/core.py:265
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -143,110 +143,110 @@ msgstr ""
 "%(within)s içinde giriş yapmadınız. Yeni giriş yapma talimatları "
 "%(email)s adresine gönderilmiştir."
 
-#: flask_security/core.py:271
+#: flask_security/core.py:272
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Giriş yapma talimatları %(email)s adresine gönderilmiştir."
 
-#: flask_security/core.py:274
+#: flask_security/core.py:275
 msgid "Invalid login token."
 msgstr "Yanlış giriş kodu."
 
-#: flask_security/core.py:275
+#: flask_security/core.py:276
 msgid "Account is disabled."
 msgstr "Hesap kapalıdır."
 
-#: flask_security/core.py:276
+#: flask_security/core.py:277
 msgid "Email not provided"
 msgstr "E-posta verilmemiş"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:278
 msgid "Invalid email address"
 msgstr "Yanlış e-posta adresi"
 
-#: flask_security/core.py:278
+#: flask_security/core.py:279
 msgid "Password not provided"
 msgstr "Şifre verilmemiş"
 
-#: flask_security/core.py:279
+#: flask_security/core.py:280
 msgid "No password is set for this user"
 msgstr "Bu kullanıcı için bir şifre yok"
 
-#: flask_security/core.py:280
+#: flask_security/core.py:281
 msgid "Password must be at least 6 characters"
 msgstr "Şifreniz en az 6 karakter olmalıdır"
 
-#: flask_security/core.py:281
+#: flask_security/core.py:282
 msgid "Specified user does not exist"
 msgstr "Böyle bir kullanıcı yok"
 
-#: flask_security/core.py:282
+#: flask_security/core.py:283
 msgid "Invalid password"
 msgstr "Şifre yanlış"
 
-#: flask_security/core.py:283
+#: flask_security/core.py:284
 msgid "You have successfully logged in."
 msgstr "Başarıyla giriş yaptınız."
 
-#: flask_security/core.py:284
+#: flask_security/core.py:285
 msgid "Forgot password?"
 msgstr "Şifrenizi mi unuttunuz?"
 
-#: flask_security/core.py:286
+#: flask_security/core.py:287
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "Şifreniz yenilenmiştir ve otomatik olarak giriş yapmış bulunmaktasınız."
 
-#: flask_security/core.py:293
+#: flask_security/core.py:294
 msgid "Your new password must be different than your previous password."
 msgstr "Yeni şifreniz eski şifrenizden farklı olmalıdır."
 
-#: flask_security/core.py:296
+#: flask_security/core.py:297
 msgid "You successfully changed your password."
 msgstr "Şifrenizi başarıyla değiştirdiniz."
 
-#: flask_security/core.py:297
+#: flask_security/core.py:298
 msgid "Please log in to access this page."
 msgstr "Bu sayfaya erişebilmek için lütfen giriş yapın."
 
-#: flask_security/core.py:298
+#: flask_security/core.py:299
 msgid "Please reauthenticate to access this page."
 msgstr "Bu sayfaya erişebilmek için lütfen tekrardan giriş yapın."
 
-#: flask_security/core.py:300
+#: flask_security/core.py:301
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:303
+#: flask_security/core.py:304
 msgid "Invalid Token"
 msgstr ""
 
-#: flask_security/core.py:304
+#: flask_security/core.py:305
 msgid "Your token has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:306
+#: flask_security/core.py:307
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:310
+#: flask_security/core.py:311
 msgid "You successfully confirmed password"
 msgstr ""
 
-#: flask_security/core.py:314
+#: flask_security/core.py:315
 msgid "Password confirmation is needed in order to access page"
 msgstr ""
 
-#: flask_security/core.py:318
+#: flask_security/core.py:319
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:321
+#: flask_security/core.py:322
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:323
+#: flask_security/core.py:324
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
@@ -337,6 +337,10 @@ msgstr "Şifre değiştir"
 msgid "Send password reset instructions"
 msgstr "Şifre değiştirme talimatlarını gönder"
 
+#: flask_security/templates/security/logout_user.html:6
+msgid "Logout"
+msgstr ""
+
 #: flask_security/templates/security/reset_password.html:6
 msgid "Reset password"
 msgstr "Şifre yenile"
@@ -361,8 +365,8 @@ msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:21
 msgid ""
-"Open your authenticator app on your device and scan the following qrcode "
-"to start receiving codes:"
+"Open Google Authenticator on your device and scan the following qrcode to"
+" start receiving codes:"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:22

--- a/flask_security/translations/zh_Hans_CN/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/zh_Hans_CN/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2019-12-14 21:54-0800\n"
+"POT-Creation-Date: 2020-02-07 19:25+0900\n"
 "PO-Revision-Date: 2018-08-02 19:55+0800\n"
 "Last-Translator: SteinKuo <guoming054@gmail.com>\n"
 "Language: zh_CN\n"
@@ -17,231 +17,231 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: flask_security/core.py:179
+#: flask_security/core.py:180
 msgid "Login Required"
 msgstr "需要登录"
 
-#: flask_security/core.py:180
+#: flask_security/core.py:181
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 msgid "Welcome"
 msgstr "欢迎"
 
-#: flask_security/core.py:181
+#: flask_security/core.py:182
 msgid "Please confirm your email"
 msgstr "请激活你的电子邮箱"
 
-#: flask_security/core.py:182
+#: flask_security/core.py:183
 msgid "Login instructions"
 msgstr "登录邮件"
 
-#: flask_security/core.py:183
+#: flask_security/core.py:184
 #: flask_security/templates/security/email/reset_notice.html:1
 msgid "Your password has been reset"
 msgstr "你的密码已重置"
 
-#: flask_security/core.py:184
+#: flask_security/core.py:185
 msgid "Your password has been changed"
 msgstr "你的密码已更改"
 
-#: flask_security/core.py:185
+#: flask_security/core.py:186
 msgid "Password reset instructions"
 msgstr "密码重置"
 
-#: flask_security/core.py:188
+#: flask_security/core.py:189
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:189
+#: flask_security/core.py:190
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:219
+#: flask_security/core.py:220
 msgid "You do not have permission to view this resource."
 msgstr "你无权查看此资源！"
 
-#: flask_security/core.py:221
+#: flask_security/core.py:222
 msgid "You are not authenticated. Please supply the correct credentials."
 msgstr ""
 
-#: flask_security/core.py:225
+#: flask_security/core.py:226
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "谢谢你。已发送激活邮件到 %(email)s。"
 
-#: flask_security/core.py:228
+#: flask_security/core.py:229
 msgid "Thank you. Your email has been confirmed."
 msgstr "谢谢。你的邮箱已激活！"
 
-#: flask_security/core.py:229
+#: flask_security/core.py:230
 msgid "Your email has already been confirmed."
 msgstr "你的邮箱已激活！"
 
-#: flask_security/core.py:230
+#: flask_security/core.py:231
 msgid "Invalid confirmation token."
 msgstr "无效验证码！"
 
-#: flask_security/core.py:232
+#: flask_security/core.py:233
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s 已关联账户。"
 
-#: flask_security/core.py:235
+#: flask_security/core.py:236
 msgid "Password does not match"
 msgstr "密码不匹配"
 
-#: flask_security/core.py:236
+#: flask_security/core.py:237
 msgid "Passwords do not match"
 msgstr "密码不匹配"
 
-#: flask_security/core.py:237
+#: flask_security/core.py:238
 msgid "Redirections outside the domain are forbidden"
 msgstr "禁止域名外重定向"
 
-#: flask_security/core.py:239
+#: flask_security/core.py:240
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr "重置密码邮件已发送到 %(email)s。"
 
-#: flask_security/core.py:243
+#: flask_security/core.py:244
 #, python-format
 msgid ""
 "You did not reset your password within %(within)s. New instructions have "
 "been sent to %(email)s."
 msgstr "你未在 %(within)s 重置密码。新重置密码邮件已发送到 %(email)s。"
 
-#: flask_security/core.py:249
+#: flask_security/core.py:250
 msgid "Invalid reset password token."
 msgstr "密码重置验证码无效！"
 
-#: flask_security/core.py:250
+#: flask_security/core.py:251
 msgid "Email requires confirmation."
 msgstr "请先激活邮箱。"
 
-#: flask_security/core.py:252
+#: flask_security/core.py:253
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "激活邮件已发送到  %(email)s。"
 
-#: flask_security/core.py:256
+#: flask_security/core.py:257
 #, python-format
 msgid ""
 "You did not confirm your email within %(within)s. New instructions to "
 "confirm your email have been sent to %(email)s."
 msgstr "你未在 %(within)s 激活邮箱。新激活邮件已发送到 %(email)s。"
 
-#: flask_security/core.py:264
+#: flask_security/core.py:265
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
 "sent to %(email)s."
 msgstr "你未在 %(within)s 登录账户。新登录邮件已发送到 %(email)s。"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:272
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "登录邮件已发送到 %(email)s。"
 
-#: flask_security/core.py:274
+#: flask_security/core.py:275
 msgid "Invalid login token."
 msgstr "无效登录验证码！"
 
-#: flask_security/core.py:275
+#: flask_security/core.py:276
 msgid "Account is disabled."
 msgstr "账户已被禁用！"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:277
 msgid "Email not provided"
 msgstr "未填写电子邮箱"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:278
 msgid "Invalid email address"
 msgstr "无效邮箱地址"
 
-#: flask_security/core.py:278
+#: flask_security/core.py:279
 msgid "Password not provided"
 msgstr "未填写密码"
 
-#: flask_security/core.py:279
+#: flask_security/core.py:280
 msgid "No password is set for this user"
 msgstr "此账户未设置密码"
 
-#: flask_security/core.py:280
+#: flask_security/core.py:281
 msgid "Password must be at least 6 characters"
 msgstr "密码至少6个字符"
 
-#: flask_security/core.py:281
+#: flask_security/core.py:282
 msgid "Specified user does not exist"
 msgstr "此用户不存在"
 
-#: flask_security/core.py:282
+#: flask_security/core.py:283
 msgid "Invalid password"
 msgstr "密码不正确"
 
-#: flask_security/core.py:283
+#: flask_security/core.py:284
 msgid "You have successfully logged in."
 msgstr "你已成功登录！"
 
-#: flask_security/core.py:284
+#: flask_security/core.py:285
 msgid "Forgot password?"
 msgstr "忘记密码？"
 
-#: flask_security/core.py:286
+#: flask_security/core.py:287
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "你的密码已成功重置，并已自动登录。"
 
-#: flask_security/core.py:293
+#: flask_security/core.py:294
 msgid "Your new password must be different than your previous password."
 msgstr "你的新密码不能与当前密码相同。"
 
-#: flask_security/core.py:296
+#: flask_security/core.py:297
 msgid "You successfully changed your password."
 msgstr "你已成功更改密码！"
 
-#: flask_security/core.py:297
+#: flask_security/core.py:298
 msgid "Please log in to access this page."
 msgstr "请登录访问此页面。"
 
-#: flask_security/core.py:298
+#: flask_security/core.py:299
 msgid "Please reauthenticate to access this page."
 msgstr "请重新进行身份验证，以访问此页面。"
 
-#: flask_security/core.py:300
+#: flask_security/core.py:301
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:303
+#: flask_security/core.py:304
 msgid "Invalid Token"
 msgstr ""
 
-#: flask_security/core.py:304
+#: flask_security/core.py:305
 msgid "Your token has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:306
+#: flask_security/core.py:307
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:310
+#: flask_security/core.py:311
 msgid "You successfully confirmed password"
 msgstr ""
 
-#: flask_security/core.py:314
+#: flask_security/core.py:315
 msgid "Password confirmation is needed in order to access page"
 msgstr ""
 
-#: flask_security/core.py:318
+#: flask_security/core.py:319
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:321
+#: flask_security/core.py:322
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:323
+#: flask_security/core.py:324
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
@@ -332,6 +332,10 @@ msgstr "更改密码"
 msgid "Send password reset instructions"
 msgstr "发送密码重置邮件"
 
+#: flask_security/templates/security/logout_user.html:6
+msgid "Logout"
+msgstr ""
+
 #: flask_security/templates/security/reset_password.html:6
 msgid "Reset password"
 msgstr "重置密码"
@@ -356,8 +360,8 @@ msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:21
 msgid ""
-"Open your authenticator app on your device and scan the following qrcode "
-"to start receiving codes:"
+"Open Google Authenticator on your device and scan the following qrcode to"
+" start receiving codes:"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:22

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -197,7 +197,7 @@ def login():
         )
 
 
-def logout():
+def logout_without_form():
     """View function which handles a logout request."""
     tf_clean_session()
 
@@ -216,13 +216,20 @@ def logout_with_form():
     form = _security.logout_form(request.form)
 
     if form.validate_on_submit():
-        response = logout()
-        assert not current_user.is_authenticated
+        response = logout_without_form()
         return response
 
     return _security.render_template(
         config_value("LOGOUT_USER_TEMPLATE"), logout_user_form=form, **_ctx("logout")
     )
+
+
+def logout():
+    """View function which handles a logout request."""
+    if _security.logout_form:
+        return logout_with_form()
+
+    return logout_without_form()
 
 
 @anonymous_user_required
@@ -1032,12 +1039,7 @@ def create_blueprint(state, import_name, json_encoder=None):
     if json_encoder:
         bp.json_encoder = json_encoder
 
-    if state.logout_form:
-        bp.route(state.logout_url, methods=["GET", "POST"], endpoint="logout")(
-            logout_with_form
-        )
-    else:
-        bp.route(state.logout_url, methods=["GET", "POST"], endpoint="logout")(logout)
+    bp.route(state.logout_url, methods=["GET", "POST"], endpoint="logout")(logout)
 
     if state.passwordless:
         bp.route(state.login_url, methods=["GET", "POST"], endpoint="login")(send_login)


### PR DESCRIPTION
- Add the option to logout only with POST request (possibly using CSRF Tokens).
- At the same time, allows specifying a form for the logout page.

This may answer #112 , although I'm not sure if @golyalpha was only talking about the JSON API or removing logout functionality from the GET request (which #79 does not do).