### PR TITLE
Provide an interface so applications can catch and mitigate send_code errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,13 +8,15 @@ Version 3.4.0
 
 Released Target Feb 2020
 
-- (:issue:`99`, :issue:`195`) Support pluggable password validators. Provide a default
-  validator that offers complexity and breached support.
 - (:pr:`257`) Support a unified sign in feature. Please see :ref:`unified-sign-in`.
 - (:pr:`265`) Add phone number validation class. This is used in both unified sign in
   as well as two-factor when using ``sms``.
 - (:pr:`274`) Add support for 'freshness' of caller's authentication. This permits endpoints
   to be additionally protected by ensuring a recent authentication.
+- (:issue:`99`, :issue:`195`) Support pluggable password validators. Provide a default
+  validator that offers complexity and breached support.
+- (:issue:`266`) Provide interface to two-factor send_token so that applications
+  can provide error mitigation. Defaults to returning errors if can't send the verification code.
 
 As part of adding unified sign in, there were many similarities with two-factor.
 Some refactoring was done to unify naming, configuration variables etc.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -128,6 +128,8 @@ Utils
 
 .. autofunction:: flask_security.us_send_security_token
 
+.. autofunction:: flask_security.tf_send_security_token
+
 .. autoclass:: flask_security.FsJsonEncoder
 
 .. autoclass:: flask_security.Totp

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -67,6 +67,7 @@ from .signals import (
     us_profile_changed,
 )
 from .totp import Totp
+from .twofactor import tf_send_security_token
 from .unified_signin import (
     UnifiedSigninForm,
     UnifiedSigninSetupForm,

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -45,6 +45,7 @@ from .forms import (
     TwoFactorRescueForm,
 )
 from .phone_util import PhoneUtil
+from .twofactor import tf_send_security_token
 from .unified_signin import (
     UnifiedSigninForm,
     UnifiedSigninSetupForm,
@@ -808,7 +809,7 @@ class UserMixin(BaseUserMixin):
 
     def calc_username(self):
         """ Come up with the best 'username' based on how the app
-        is configured (via SECURITY_USER_IDENTITY_ATTRIBUTES).
+        is configured (via :py:data:`SECURITY_USER_IDENTITY_ATTRIBUTES`).
         Returns the first non-null match (and converts to string).
         In theory this should NEVER be the empty string unless the user
         record isn't actually valid.
@@ -857,6 +858,24 @@ class UserMixin(BaseUserMixin):
         """
         try:
             us_send_security_token(self, method, **kwargs)
+        except Exception:
+            return get_message("FAILED_TO_SEND_CODE")[0]
+        return None
+
+    def tf_send_security_token(self, method, **kwargs):
+        """ Generate and send the security code for two-factor.
+
+        :param method: The method in which the code will be sent
+        :param kwargs: Opaque parameters that are subject to change at any time
+        :return: None if successful, error message if not.
+
+        This is a wrapper around :meth:`tf_send_security_token`
+        that can be overridden to manage any errors.
+
+        .. versionadded:: 3.4.0
+        """
+        try:
+            tf_send_security_token(self, method, **kwargs)
         except Exception:
             return get_message("FAILED_TO_SEND_CODE")[0]
         return None

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -571,7 +571,7 @@ class TwoFactorVerifyPasswordForm(Form, PasswordFormMixin):
         return True
 
 
-class TwoFactorRescueForm(Form, UserEmailFormMixin):
+class TwoFactorRescueForm(Form):
     """The Two-factor Rescue validation form """
 
     help_setup = RadioField(
@@ -587,4 +587,6 @@ class TwoFactorRescueForm(Form, UserEmailFormMixin):
         super(TwoFactorRescueForm, self).__init__(*args, **kwargs)
 
     def validate(self):
+        if not super(TwoFactorRescueForm, self).validate():
+            return False
         return True

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -310,7 +310,9 @@ def us_send_code():
 
         if _security._want_json(request):
             # Not authenticated yet - so don't send any user info.
-            return base_render_json(form, include_user=False)
+            return base_render_json(
+                form, include_user=False, error_status_code=500 if msg else 400
+            )
 
         return _security.render_template(
             config_value("US_SIGNIN_TEMPLATE"),
@@ -502,7 +504,9 @@ def us_setup():
             form.chosen_method.errors.append(msg)
             if _security._want_json(request):
                 # Not authenticated yet - so don't send any user info.
-                return base_render_json(form, include_user=False)
+                return base_render_json(
+                    form, include_user=False, error_status_code=500 if msg else 400
+                )
             return _security.render_template(
                 config_value("US_SETUP_TEMPLATE"),
                 methods=config_value("US_ENABLED_METHODS"),
@@ -657,17 +661,20 @@ def us_send_security_token(
     user, method, totp_secret, phone_number, send_magic_link=False
 ):
     """ Generate and send the security code.
+
     :param user: The user to send the code to
     :param method: The method in which the code will be sent
     :param totp_secret: the unique shared secret of the user
     :param phone_number: If 'sms' phone number to send to
     :param send_magic_link: If true a magic link that can be clicked on will be sent.
+
     This shouldn't be sent during a setup.
 
     There is no return value - it is assumed that exceptions are thrown by underlying
     methods that callers can catch.
 
-    Flask-Security code should NOT call this directly - call user.us_send_security_token
+    Flask-Security code should NOT call this directly -
+    call :meth:`.UserMixin.us_send_security_token`
 
     .. versionadded:: 3.4.0
     """

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -756,13 +756,17 @@ def csrf_cookie_handler(response):
 
 
 def base_render_json(
-    form, include_user=True, include_auth_token=False, additional=None
+    form,
+    include_user=True,
+    include_auth_token=False,
+    additional=None,
+    error_status_code=400,
 ):
     has_errors = len(form.errors) > 0
 
     user = form.user if hasattr(form, "user") else None
     if has_errors:
-        code = 400
+        code = error_status_code
         payload = json_error_response(errors=form.errors)
     else:
         code = 200

--- a/tests/test_context_processors.py
+++ b/tests/test_context_processors.py
@@ -7,7 +7,7 @@
 """
 
 import pytest
-from test_two_factor import two_factor_authenticate
+from test_two_factor import tf_authenticate
 from test_unified_signin import authenticate as us_authenticate
 from utils import authenticate, logout
 
@@ -122,7 +122,7 @@ def test_two_factor_context_processors(client, app):
     def send_two_factor_confirm():
         return {"foo": "bar"}
 
-    two_factor_authenticate(client)
+    tf_authenticate(app, client)
     response = client.get("/tf-confirm")
     assert b"global" in response.data
     assert b"bar" in response.data
@@ -143,7 +143,7 @@ def test_two_factor_context_processors(client, app):
     def send_two_factor_token_validation():
         return {"foo": "bar"}
 
-    two_factor_authenticate(client, validate=False)
+    tf_authenticate(app, client, validate=False)
     response = client.get("/tf-rescue")
     assert b"global" in response.data
     assert b"bar" in response.data

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -922,7 +922,7 @@ def test_bad_sender(app, client, get_message):
     assert get_message("FAILED_TO_SEND_CODE") in response.data
 
     response = client.post("us-send-code", data=json.dumps(data), headers=headers)
-    assert response.status_code == 400
+    assert response.status_code == 500
     assert response.jdata["response"]["errors"]["chosen_method"][0].encode(
         "utf-8"
     ) == get_message("FAILED_TO_SEND_CODE")
@@ -934,7 +934,7 @@ def test_bad_sender(app, client, get_message):
     assert get_message("FAILED_TO_SEND_CODE") in response.data
 
     response = client.post("us-setup", data=json.dumps(data), headers=headers)
-    assert response.status_code == 400
+    assert response.status_code == 500
     assert response.jdata["response"]["errors"]["chosen_method"][0].encode(
         "utf-8"
     ) == get_message("FAILED_TO_SEND_CODE")


### PR DESCRIPTION
Two-factor auth attempts to send a verification code. If that fails there was
no way for applications to intercept and perform any mitigation. Furthermore,
an exception would be thrown and a 500 returned w/o any indication of what
went wrong.

This PR fixes that by providing an overridable method in the UserMixin that
can capture and mitigate errors. The default implementation returns an error message.
The various view functions now check for errors and act accordingly.

closes: #266