### PR TITLE
HTTP request methods for Logout

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -468,6 +468,13 @@ Login/Logout
     Default:``"/logout"``.
 
 
+.. py:data:: SECURITY_LOGOUT_METHODS
+
+    Specifies the HTTP request methods that the logout URL accepts. Specify ``None`` to disable the logout URL (and implement your own).
+
+    Default:``["GET", "POST"]``.
+
+
 .. py:data:: SECURITY_POST_LOGIN_VIEW
 
     Specifies the default view to redirect to after a user logs in. This value can be set to a URL

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -471,8 +471,9 @@ Login/Logout
 .. py:data:: SECURITY_LOGOUT_METHODS
 
     Specifies the HTTP request methods that the logout URL accepts. Specify ``None`` to disable the logout URL (and implement your own).
+    Configuring with just ``["POST"]`` is slightly more secure. The default includes ``"GET"`` for backwards compatibility.
 
-    Default:``["GET", "POST"]``.
+    Default: ``["GET", "POST"]``.
 
 
 .. py:data:: SECURITY_POST_LOGIN_VIEW

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -144,6 +144,7 @@ _default_config = {
     "TWO_FACTOR_QRCODE_URL": "/tf-qrcode",
     "TWO_FACTOR_RESCUE_URL": "/tf-rescue",
     "TWO_FACTOR_CONFIRM_URL": "/tf-confirm",
+    "LOGOUT_METHODS": ["GET", "POST"],
     "POST_LOGIN_VIEW": "/",
     "POST_LOGOUT_VIEW": "/",
     "CONFIRM_ERROR_VIEW": None,

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -1031,7 +1031,7 @@ def create_blueprint(state, import_name, json_encoder=None):
     if json_encoder:
         bp.json_encoder = json_encoder
 
-    bp.route(state.logout_url, methods=["GET", "POST"], endpoint="logout")(logout)
+    bp.route(state.logout_url, methods=state.logout_methods, endpoint="logout")(logout)
 
     if state.passwordless:
         bp.route(state.login_url, methods=["GET", "POST"], endpoint="login")(send_login)

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -1031,7 +1031,10 @@ def create_blueprint(state, import_name, json_encoder=None):
     if json_encoder:
         bp.json_encoder = json_encoder
 
-    bp.route(state.logout_url, methods=state.logout_methods, endpoint="logout")(logout)
+    if state.logout_methods is not None:
+        bp.route(state.logout_url, methods=state.logout_methods, endpoint="logout")(
+            logout
+        )
 
     if state.passwordless:
         bp.route(state.login_url, methods=["GET", "POST"], endpoint="login")(send_login)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -210,16 +210,10 @@ def test_passwordless_custom_form(app, sqlalchemy_datastore):
     assert b"My Passwordless Email Address Field" in response.data
 
 
-@pytest.mark.parametrize('logout_methods', (
-    ["GET", "POST"],
-    ["GET"],
-    ["POST"],
-))
+@pytest.mark.parametrize("logout_methods", (["GET", "POST"], ["GET"], ["POST"]))
 def test_logout_methods(app, sqlalchemy_datastore, logout_methods):
     init_app_with_options(
-        app,
-        sqlalchemy_datastore,
-        **{"SECURITY_LOGOUT_METHODS": logout_methods}
+        app, sqlalchemy_datastore, **{"SECURITY_LOGOUT_METHODS": logout_methods}
     )
 
     client = app.test_client()
@@ -243,6 +237,24 @@ def test_logout_methods(app, sqlalchemy_datastore, logout_methods):
 
     else:
         assert response.status_code == 405  # method not allowed
+
+
+def test_logout_methods_none(app, sqlalchemy_datastore):
+    init_app_with_options(
+        app, sqlalchemy_datastore, **{"SECURITY_LOGOUT_METHODS": None}
+    )
+
+    client = app.test_client()
+
+    authenticate(client)
+
+    response = client.get("/logout", follow_redirects=True)
+
+    assert response.status_code == 404
+
+    response = client.post("/logout", follow_redirects=True)
+
+    assert response.status_code == 404
 
 
 def test_addition_identity_attributes(app, sqlalchemy_datastore):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -210,6 +210,41 @@ def test_passwordless_custom_form(app, sqlalchemy_datastore):
     assert b"My Passwordless Email Address Field" in response.data
 
 
+@pytest.mark.parametrize('logout_methods', (
+    ["GET", "POST"],
+    ["GET"],
+    ["POST"],
+))
+def test_logout_methods(app, sqlalchemy_datastore, logout_methods):
+    init_app_with_options(
+        app,
+        sqlalchemy_datastore,
+        **{"SECURITY_LOGOUT_METHODS": logout_methods}
+    )
+
+    client = app.test_client()
+
+    authenticate(client)
+
+    response = client.get("/logout", follow_redirects=True)
+
+    if "GET" in logout_methods:
+        assert response.status_code == 200
+
+        authenticate(client)
+
+    else:
+        assert response.status_code == 405  # method not allowed
+
+    response = client.post("/logout", follow_redirects=True)
+
+    if "POST" in logout_methods:
+        assert response.status_code == 200
+
+    else:
+        assert response.status_code == 405  # method not allowed
+
+
 def test_addition_identity_attributes(app, sqlalchemy_datastore):
     init_app_with_options(
         app,


### PR DESCRIPTION
This Pull Request is in response to the changes mentioned in #275

This implements the `SECURITY_LOGOUT_METHODS` configuration value that can restrict the HTTP request methods that the logout endpoint accepts. It can also be used to totally disable the endpoint.

This may or may not answer #112, and can be thought of as a continuation of #79 .