### PR TITLE
Integrate freshness checking into unified sign in setup endpoint.

### DIFF
--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -21,11 +21,13 @@ following is a list of view templates:
 * `security/change_password.html`
 * `security/send_confirmation.html`
 * `security/send_login.html`
+* `security/verify.html`
 * `security/two_factor_verify_password.html`
 * `security/two_factor_setup.html`
 * `security/two_factor_verify_code.html`
 * `security/us_signin.html`
 * `security/us_setup.html`
+* `security/us_verify.html`
 
 Overriding these templates is simple:
 

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -146,6 +146,11 @@ an authenticator application, the :py:data:`SECURITY_US_MFA_REQUIRED` configurat
 determines which primary authentication mechanisms require a second factor. By default
 limited to ``email`` and ``password`` (if two-factor is enabled).
 
+Be aware that by default, the :py:data:`SECURITY_US_SETUP_URL` endpoint is protected
+with a freshness check (see :meth:`flask_security.auth_required`) which means it requires a session
+cookie to function properly. This is true even if using JSON payload or token authentication.
+If you disable the freshness check then sessions aren't required.
+
 `Current Limited Functionality`:
 
     * Change password does not work if a user registers without a password. However

--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -28,10 +28,6 @@ Also, if you annotate your endpoints with JUST an authorization decorator, you w
 get a 401 response, and (for forms) you won't be redirected to your login page. In this case
 you will always get a 403 status code (assuming you don't override the default handlers).
 
-:func:`.auth_required` also provides a mechanism to check for freshness; that is, require that the
-caller has authenticated within a specified window. This is commonly used when the endpoint is protecting
-modifications to sensitive information. Flask-Security uses this as part of securing the :ref:`unified-sign-in` setup endpoint.
-
 While these annotations are quick and easy, it is likely that they won't completely satisfy
 all an application's authorization requirements. A common example might be that a user can
 only edit their own posts/documents. In cases like this - it is nice to have a uniform way
@@ -61,6 +57,22 @@ own code. Then use Flask's ``errorhandler`` to catch that exception and create t
             raise MyForbiddenException(msg='You can only update docs you own')
 
 
+Freshness
+++++++++++
+A common pattern for browser-based sites is to use sessions to manage identity. This is usually
+implemented using session cookies. These cookies expire once the session (browser tab) is closed. This is very
+convenient, and keep the users from having to constantly re-authenticate. The downside is that sessions can easily be
+open for days or weeks. This adds to the security risk that some bad-actor or XSS gets control of the browser and then can
+do anything the user can. To mitigate that, operations that change fundamental identity characteristics (such as email, password, etc.)
+can be protected by requiring a 'fresh' or recent authentication. Flask-Security supports this with the following:
+
+    - :func:`.auth_required` takes parameters that define how recent the authentication must have happened. In addition a grace
+      period can be specified so that multiple step operations don't require re-authentication in the middle.
+    - A default :meth:`.Security.reauthn_handler` that is called when a request fails the recent authentication check
+    - :py:data:`SECURITY_VERIFY_URL` and :py:data:`SECURITY_US_VERIFY_URL` endpoints that request the user to re-authenticate
+    - VerifyForm and UsVerifyForm forms that can be extended.
+
+Flask-Security itself uses this as part of securing the :ref:`unified-sign-in` setup endpoint.
 
 .. _pass_validation_topic:
 

--- a/docs/spa.rst
+++ b/docs/spa.rst
@@ -39,6 +39,7 @@ An example configuration::
     SECURITY_CHANGEABLE = True
     SECURITY_CONFIRMABLE = True
     SECURITY_REGISTERABLE = True
+    SECURITY_UNIFIED_SIGNIN = True
 
     # These need to be defined to handle redirects
     # As defined in the API documentation - they will receive the relevant context

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -48,6 +48,7 @@ from .forms import (
     TwoFactorSetupForm,
     TwoFactorVerifyCodeForm,
     TwoFactorVerifyPasswordForm,
+    VerifyForm,
 )
 from .phone_util import PhoneUtil
 from .signals import (
@@ -72,6 +73,7 @@ from .unified_signin import (
     UnifiedSigninForm,
     UnifiedSigninSetupForm,
     UnifiedSigninSetupVerifyForm,
+    UnifiedVerifyForm,
     us_send_security_token,
 )
 from .utils import (

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -344,6 +344,23 @@ class LoginForm(Form, NextFormMixin):
         return True
 
 
+class VerifyForm(Form, PasswordFormMixin):
+    """The verify authentication form"""
+
+    user = None
+    submit = SubmitField(get_form_field_label("verify_password"))
+
+    def validate(self):
+        if not super(VerifyForm, self).validate():
+            return False
+
+        self.user = current_user
+        if not self.user.verify_and_update_password(self.password.data):
+            self.password.errors.append(get_message("INVALID_PASSWORD")[0])
+            return False
+        return True
+
+
 class ConfirmRegisterForm(Form, RegisterFormMixin, UniqueEmailFormMixin):
     """ This form is used for registering when 'confirmable' is set.
     The only difference between this and the other RegisterForm is that

--- a/flask_security/templates/security/us_setup.html
+++ b/flask_security/templates/security/us_setup.html
@@ -3,7 +3,7 @@
 
 {% block content %}
     {% include "security/_messages.html" %}
-    <h1>{{ _("Setup and verify unified sign in options") }}</h1>
+    <h1>{{ _("Setup Unified Sign In options") }}</h1>
     <form action="{{ url_for_security("us_setup") }}" method="POST"
           name="us_setup_form">
       {{ us_setup_form.hidden_tag() }}

--- a/flask_security/templates/security/us_signin.html
+++ b/flask_security/templates/security/us_signin.html
@@ -22,7 +22,7 @@
         {% if code_sent %}
           <p>{{ _("Code has been sent") }}
         {% endif %}
-        {{ render_field(us_signin_form.submit_send_code, formaction=url_for_security('us_send_code')) }}
+        {{ render_field(us_signin_form.submit_send_code, formaction=url_for_security('us_signin_send_code')) }}
       {% endif %}
       </form>
   {% include "security/_menu.html" %}

--- a/flask_security/templates/security/us_verify.html
+++ b/flask_security/templates/security/us_verify.html
@@ -1,0 +1,27 @@
+{% extends "security/base.html" %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors %}
+
+{% block content %}
+    {% include "security/_messages.html" %}
+    <h1>{{ _("Please re-authenticate") }}</h1>
+      <form action="{{ url_for_security("us_verify") }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}" method="POST"
+          name="us_verify_form">
+      {{ us_verify_form.hidden_tag() }}
+      {{ render_field_with_errors(us_verify_form.passcode) }}
+      {{ render_field(us_verify_form.submit) }}
+      {% if methods %}
+        <h4>{{  _("Request one-time code be sent") }}</h4>
+        {% for subfield in us_verify_form.chosen_method %}
+          {% if subfield.data in methods %}
+            {{ render_field_with_errors(subfield) }}
+          {% endif %}
+        {% endfor %}
+        {{ render_field_errors(us_verify_form.chosen_method) }}
+        {% if code_sent %}
+          <p>{{ _("Code has been sent") }}
+        {% endif %}
+        {{ render_field(us_verify_form.submit_send_code, formaction=send_code_to) }}
+      {% endif %}
+      </form>
+  {% include "security/_menu.html" %}
+{% endblock %}

--- a/flask_security/templates/security/verify.html
+++ b/flask_security/templates/security/verify.html
@@ -1,0 +1,13 @@
+{% extends "security/base.html" %}
+{% from "security/_macros.html" import render_field_with_errors, render_field %}
+
+{% block content %}
+    {% include "security/_messages.html" %}
+    <h1>{{ _("Please Enter Your Password") }}</h1>
+    <form action="{{ url_for_security("verify") }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}" method="POST"
+          name="verify_form">
+        {{ verify_form.hidden_tag() }}
+        {{ render_field_with_errors(verify_form.password) }}
+        {{ render_field(verify_form.submit) }}
+    </form>
+{% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,6 +203,14 @@ def app(request):
     def unauthz():
         return render_template("index.html", content="Unauthorized")
 
+    @app.route("/fresh", methods=["GET", "POST"])
+    @auth_required(within=0)
+    def fresh():
+        if app.security._want_json(flask_request):
+            return jsonify(title="Fresh Only")
+        else:
+            return render_template("index.html", content="Fresh Only")
+
     return app
 
 

--- a/tests/templates/custom_security/us_verify.html
+++ b/tests/templates/custom_security/us_verify.html
@@ -1,0 +1,3 @@
+CUSTOM UNIFIED VERIFY
+{{ global }}
+{{ foo }}

--- a/tests/templates/custom_security/verify.html
+++ b/tests/templates/custom_security/verify.html
@@ -1,0 +1,3 @@
+CUSTOM VERIFY USER
+{{ global }}
+{{ foo }}

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -69,6 +69,8 @@ def create_app():
     app.config["SECURITY_TOTP_SECRETS"] = {
         "1": "TjQ9Qa31VOrfEzuPy4VHQWPCTmRzCnFzMKLxXYiZu9B"
     }
+    app.config["SECURITY_FRESHNESS"] = datetime.timedelta(minutes=5)
+    app.config["SECURITY_FRESHNESS_GRACE_PERIOD"] = datetime.timedelta(minutes=2)
 
     # Make this plaintext for most tests - reduces unit test time by 50%
     app.config["SECURITY_PASSWORD_HASH"] = "plaintext"
@@ -151,7 +153,7 @@ def create_app():
     @us_security_token_sent.connect_via(app)
     def on_us_token_sent(myapp, user, token, method, **extra):
         flash(
-            "User {} was sent passwordless token {} via {}".format(
+            "User {} was sent sign in code {} via {}".format(
                 user.calc_username(), token, method
             )
         )


### PR DESCRIPTION
It became clear that just redirecting to /login was a bad user experience and
in fact doesn't actually work.

So - create 2 new endpoints: /verify and /us-verify, and backing forms that
are just for re-authenticating. default_reauthn_handler will call one or the other
based on whether UNIFIED_SIGNIN is enabled.

Added a POST_VERIFY_VIEW that can redirect upon successful re-auth. For form-based
apps - this normally isn't needed since we properly propagate the ?next=xxx parameters.

This meant the REAUTHENTICATION_VIEW was no longer needed and was removed.

Make sure json responses provide enough info when asking for re-authentication.

Fixed bug when 'within' was 0.