### PR TITLE
Cleanup us-signin and us-setup forms when just password is configured.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ env:
 
 before_install:
   - "travis_retry pip install --upgrade pip setuptools"
-  - "travis_retry pip install twine wheel coveralls requirements-builder"
+  - "travis_retry pip install twine wheel coveralls click==7.0.0 requirements-builder"
   - "requirements-builder -e all --level=min setup.py > .travis-lowest-requirements.txt"
   - "requirements-builder -e all --level=pypi setup.py > .travis-release-requirements.txt"
 

--- a/flask_security/templates/security/_menu.html
+++ b/flask_security/templates/security/_menu.html
@@ -7,9 +7,6 @@
   {% if security.unified_signin and not skip_login_menu %}
   <li><a href="{{ url_for_security('us_signin') }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}">{{ _("Unified Sign In") }}</a><br/></li>
   {% endif %}
-  {% if security.unified_signin %}
-      <li><a href="{{ url_for_security('us_setup') }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}">{{ _("Unified Setup") }}</a><br/></li>
-  {% endif %}
   {% if security.registerable %}
   <li><a href="{{ url_for_security('register') }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}">{{ _('Register') }}</a><br/></li>
   {% endif %}

--- a/flask_security/templates/security/us_setup.html
+++ b/flask_security/templates/security/us_setup.html
@@ -7,21 +7,25 @@
     <form action="{{ url_for_security("us_setup") }}" method="POST"
           name="us_setup_form">
       {{ us_setup_form.hidden_tag() }}
-      {{ render_field_with_errors(us_setup_form.new_totp_secret) }}
-      {% for subfield in us_setup_form.chosen_method %}
-        {% if subfield.data in methods %}
-            {{ render_field_with_errors(subfield) }}
+      {% if code_methods %}
+        {{ render_field_with_errors(us_setup_form.new_totp_secret) }}
+        {% for subfield in us_setup_form.chosen_method %}
+          {% if subfield.data in methods %}
+              {{ render_field_with_errors(subfield) }}
+          {% endif %}
+        {% endfor %}
+        {{ render_field_errors(us_setup_form.chosen_method) }}
+        {% if "sms" in methods %}
+          {{ render_field_with_errors(us_setup_form.phone) }}
         {% endif %}
-      {% endfor %}
-      {{ render_field_errors(us_setup_form.chosen_method) }}
-      {% if "sms" in methods %}
-        {{ render_field_with_errors(us_setup_form.phone) }}
+        {% if chosen_method == "authenticator" %}
+          <p>{{ _("Open your authenticator app on your device and scan the following qrcode to start receiving codes:") }}</p>
+          <p><img alt="{{ _("Passwordless QRCode") }}" id="qrcode" src="{{ url_for_security("us_qrcode", token=state) }}"></p>
+        {% endif %}
+        {{ render_field(us_setup_form.submit) }}
+      {% else %}
+        <h3>{{  _("No code methods have been enabled - nothing to setup") }}</h3>
       {% endif %}
-      {% if chosen_method == "authenticator" %}
-        <p>{{ _("Open your authenticator app on your device and scan the following qrcode to start receiving codes:") }}</p>
-        <p><img alt="{{ _("Passwordless QRCode") }}" id="qrcode" src="{{ url_for_security("us_qrcode", token=state) }}"></p>
-      {% endif %}
-      {{ render_field(us_setup_form.submit) }}
     </form>
     {%  if state %}
       <form action="{{ url_for_security("us_setup_verify", token=state) }}" method="POST"

--- a/flask_security/templates/security/us_signin.html
+++ b/flask_security/templates/security/us_signin.html
@@ -11,10 +11,10 @@
       {{ render_field_with_errors(us_signin_form.passcode) }}
       {{ render_field_with_errors(us_signin_form.remember) }}
       {{ render_field(us_signin_form.submit) }}
-      {% if methods %}
+      {% if code_methods %}
         <h4>{{  _("Request one-time code be sent") }}</h4>
         {% for subfield in us_signin_form.chosen_method %}
-          {% if subfield.data in methods %}
+          {% if subfield.data in code_methods %}
             {{ render_field_with_errors(subfield) }}
           {% endif %}
         {% endfor %}

--- a/flask_security/templates/security/us_verify.html
+++ b/flask_security/templates/security/us_verify.html
@@ -9,10 +9,10 @@
       {{ us_verify_form.hidden_tag() }}
       {{ render_field_with_errors(us_verify_form.passcode) }}
       {{ render_field(us_verify_form.submit) }}
-      {% if methods %}
+      {% if code_methods %}
         <h4>{{  _("Request one-time code be sent") }}</h4>
         {% for subfield in us_verify_form.chosen_method %}
-          {% if subfield.data in methods %}
+          {% if subfield.data in code_methods %}
             {{ render_field_with_errors(subfield) }}
           {% endif %}
         {% endfor %}

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -66,6 +66,8 @@ def create_app():
     app.config["LOGIN_DISABLED"] = False
     app.config["WTF_CSRF_ENABLED"] = False
     app.config["SECURITY_USER_IDENTITY_ATTRIBUTES"] = ["email", "us_phone_number"]
+    # app.config["SECURITY_US_ENABLED_METHODS"] = ["password"]
+
     app.config["SECURITY_TOTP_SECRETS"] = {
         "1": "TjQ9Qa31VOrfEzuPy4VHQWPCTmRzCnFzMKLxXYiZu9B"
     }


### PR DESCRIPTION
This allows unified signin to be a drop in replacement for standard login.