### PR TITLE
Add example for unified sign in.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -278,7 +278,11 @@ These configuration keys are used globally across all features.
         ],
 
     Be aware that ONLY those attributes listed in ``SECURITY_USER_IDENTITY_ATTRIBUTES``
-    will be considered - regardless of the setting in this variable.
+    will be considered - regardless of the setting of this variable.
+
+    .. danger::
+        Make sure that any columns listed here are marked Unique in your UserDataStore
+        model.
 
     .. versionadded:: 3.4.0
 

--- a/docs/spa.rst
+++ b/docs/spa.rst
@@ -43,11 +43,11 @@ An example configuration::
 
     # These need to be defined to handle redirects
     # As defined in the API documentation - they will receive the relevant context
-    SECURITY_POST_CONFIRM_VIEW = '/confirmed'
-    SECURITY_CONFIRM_ERROR_VIEW = '/confirm-error
-    SECURITY_RESET_VIEW = '/reset-password'
-    SECURITY_RESET_ERROR_VIEW = '/reset-password'
-    SECURITY_REDIRECT_BEHAVIOR = 'spa'
+    SECURITY_POST_CONFIRM_VIEW = "/confirmed"
+    SECURITY_CONFIRM_ERROR_VIEW = "/confirm-error"
+    SECURITY_RESET_VIEW = "/reset-password"
+    SECURITY_RESET_ERROR_VIEW = "/reset-password"
+    SECURITY_REDIRECT_BEHAVIOR = "spa"
 
     # CSRF protection is critical for all session-based browser UIs
 

--- a/examples/fsqlalchemy1/app.py
+++ b/examples/fsqlalchemy1/app.py
@@ -162,4 +162,4 @@ def update_blog(bid):
 
 
 if __name__ == "__main__":
-    app.run(port=5001)
+    app.run(port=5003)

--- a/examples/unified_signin/client/client.py
+++ b/examples/unified_signin/client/client.py
@@ -1,0 +1,193 @@
+"""
+Copyright 2020 by J. Christopher Wagner (jwag). All rights reserved.
+:license: MIT, see LICENSE for more details.
+
+This relies on session/session cookie for continued authentication.
+It assumes server is set up to send a CSRF cookie.
+
+We assume server doesn't require CSRF for unauthenticated endpoints.
+
+Note that we have to manually take the CSRF cookie and send it as a header.
+For many javascript http clients - they do this as part of default configuration.
+
+"""
+
+import logging
+import random
+import re
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class ApiException(Exception):
+    def __init__(self, msg, status_code):
+        if isinstance(msg, list):
+            self.msg = msg
+        else:
+            self.msg = [msg]
+        self.status_code = status_code
+
+    def get_msgs(self):
+        return ", ".join(self.msg)
+
+
+def check_error(resp):
+    # look for errors from Flask-Security API and throw exception with info
+    jresp = resp.json()
+    rdata = jresp.get("response")
+    if not rdata:
+        raise ApiException("Bad Api Response", resp.status_code)
+    if "error" in rdata:
+        raise ApiException(rdata["error"], resp.status_code)
+    if "errors" in rdata:
+        # these are form errors a dict of form label: [list of errors]
+        msgs = []
+        for l, emsgs in rdata["errors"].items():
+            msgs.extend(["{}-{}".format(l, msg) for msg in emsgs])
+        raise ApiException(msgs, resp.status_code)
+    if resp.status_code >= 400:
+        raise ApiException("Error status w/o response", resp.status_code)
+    return None
+
+
+def register(server_url, session, email, password):
+    # Register new email with password
+    # Use the backdoor to grab confirmation email and confirm.
+
+    resp = session.post(
+        "{}/register".format(server_url), json={"email": email, "password": password},
+    )
+    check_error(resp)
+
+    resp = session.get("{}/api/popmail".format(server_url))
+    if resp.status_code != 200:
+        raise ApiException("popmail error", resp.status_code)
+
+    jbody = resp.json()
+
+    # Parse for link
+    matcher = re.match(
+        r".*(http://[^\s*]*).*", jbody["mail"], re.IGNORECASE | re.DOTALL
+    )
+    magic_link = matcher.group(1)
+
+    # Note this simulates someone clicking on the email link - no point in claiming
+    # this is json.
+    resp = session.get(magic_link, allow_redirects=False)
+    assert resp.status_code == 302
+
+
+def ussetup(server_url, session, password, phone):
+    # unified sign in - setup sms with a phone number
+    # Use the backdoor to grab verification SMS.
+
+    csrf_token = session.cookies["XSRF-TOKEN"]
+    resp = session.post(
+        "{}/us-setup".format(server_url),
+        json={"chosen_method": "us_phone_number", "phone": phone},
+        headers={"X-XSRF-Token": csrf_token},
+    )
+
+    # this should be a 401 reauth required
+    assert resp.status_code == 401
+    jbody = resp.json()
+    assert jbody["response"]["reauth_required"]
+
+    # re-verify
+    resp = session.post(
+        "{}/us-verify".format(server_url),
+        json={"passcode": password},
+        headers={"X-XSRF-Token": csrf_token},
+    )
+    assert resp.status_code == 200
+
+    # try again
+    resp = session.post(
+        "{}/us-setup".format(server_url),
+        json={"chosen_method": "sms", "phone": phone},
+        headers={"X-XSRF-Token": csrf_token},
+    )
+    check_error(resp)
+    jbody = resp.json()
+    state = jbody["response"]["state"]
+
+    resp = session.get("{}/api/popsms".format(server_url))
+    if resp.status_code != 200:
+        raise ApiException("popsms error", resp.status_code)
+
+    jbody = resp.json()
+    code = jbody["sms"].split()[-1].strip(".")
+    resp = session.post(
+        "{}/us-setup/{}".format(server_url, state),
+        json={"code": code},
+        headers={"X-XSRF-Token": csrf_token},
+    )
+    check_error(resp)
+
+
+def sms_signin(server_url, session, username, phone):
+    # Sign in using SMS code.
+    session.post(
+        "{}/us-signin/send-code".format(server_url),
+        json={"identity": username, "chosen_method": "sms"},
+    )
+
+    # Fetch code via test API
+    resp = session.get("{}/api/popsms".format(server_url))
+    if resp.status_code != 200:
+        raise ApiException("popsms error", resp.status_code)
+
+    jbody = resp.json()
+    code = jbody["sms"].split()[-1].strip(".")
+    resp = session.post(
+        "{}/us-signin".format(server_url),
+        json={"identity": username, "passcode": code},
+    )
+    check_error(resp)
+
+
+def runit():
+    session = requests.session()
+    session.headers.update(
+        {"Accept": "application/json", "Content-Type": "application/json"}
+    )
+    server_url = "http://localhost:5002"
+
+    try:
+        username = "example{}@me.com".format(str(random.randint(0, 100000)))
+        mypassword = "a good easy question"
+        myphone = "+16505551212"
+
+        # New user - register and confirm
+        register(
+            server_url, session, username, mypassword,
+        )
+        # verify confirmed and logged in
+        resp = session.get("{}/api/health".format(server_url))
+        assert resp.status_code == 200
+        jresp = resp.json()
+        assert jresp["secret"] == "lush oranges"
+
+        # Now us-setup to setup a phone number
+        ussetup(server_url, session, mypassword, myphone)
+
+        # Verify can sign in with SMS
+        session.post("{}/logout".format(server_url))
+        sms_signin(server_url, session, username, myphone)
+
+        # verify logged in
+        resp = session.get("{}/api/health".format(server_url))
+        assert resp.status_code == 200
+        jresp = resp.json()
+        assert jresp["secret"] == "lush oranges"
+
+    except ApiException as exc:
+        logging.error("{}".format(exc.get_msgs()))
+
+
+if __name__ == "__main__":
+    # Run through simple sequence
+    logging.basicConfig(level=logging.INFO)
+    runit()

--- a/examples/unified_signin/server/api.py
+++ b/examples/unified_signin/server/api.py
@@ -1,0 +1,41 @@
+"""
+Copyright 2020 by J. Christopher Wagner (jwag). All rights reserved.
+:license: MIT, see LICENSE for more details.
+
+"""
+
+from datetime import datetime
+
+from flask import Blueprint, abort, current_app, jsonify
+from flask_security import auth_required
+
+from app import SmsCaptureSender
+
+api = Blueprint("api", __name__)
+
+
+@api.route("/health", methods=["GET"])
+@auth_required("session")
+def health():
+    return jsonify(secret="lush oranges", date=datetime.utcnow())
+
+
+@api.route("/popmail", methods=["GET"])
+def popmail():
+    # This gets and pops the most recently sent email
+    # Please please do not do this in your real application!
+    mailer = current_app.extensions["mail"]
+    sent = mailer.pop()
+    if sent:
+        return jsonify(mail=sent)
+    abort(400)
+
+
+@api.route("/popsms", methods=["GET"])
+def popsms():
+    # This gets and pops the most recently sent SMS
+    # Please please do not do this in your real application!
+    msg = SmsCaptureSender.pop()
+    if msg:
+        return jsonify(sms=msg)
+    abort(400)

--- a/examples/unified_signin/server/app.py
+++ b/examples/unified_signin/server/app.py
@@ -1,0 +1,153 @@
+"""
+Copyright 2020 by J. Christopher Wagner (jwag). All rights reserved.
+:license: MIT, see LICENSE for more details.
+
+A simple example of server and client utilizing unified sign in and other
+features of Flask-Security.
+
+In order to be self contained, to support things like email confirmation and
+unified sign in with email, we hack a Mail handler that stores the email link
+and an un-protected API to fetch it!
+
+This example is designed for a JSON and session cookie based client.
+
+"""
+import datetime
+import os
+
+from flask import Flask
+from flask.json import JSONEncoder
+from flask_security import Security, SmsSenderFactory, SmsSenderBaseClass
+from flask_wtf import CSRFProtect
+
+from models import db, user_datastore
+
+
+class CaptureMail(object):
+    # A hack Mail service that simply captures what would be sent.
+    def __init__(self, app):
+        app.extensions["mail"] = self
+        self.sent = list()
+
+    def send(self, msg):
+        self.sent.append(msg.body)
+
+    def pop(self):
+        if len(self.sent):
+            return self.sent.pop(0)
+        return None
+
+
+class SmsCaptureSender(SmsSenderBaseClass):
+    # A hack SMS service that records SMS messages
+    SmsSenderBaseClass.messages = []
+
+    def __init__(self):
+        super(SmsCaptureSender, self).__init__()
+        SmsSenderBaseClass.messages = []
+
+    def send_sms(self, from_number, to_number, msg):
+        SmsSenderBaseClass.messages.append(msg)
+        return
+
+    @classmethod
+    def pop(cls):
+        if len(SmsSenderBaseClass.messages):
+            return SmsSenderBaseClass.messages.pop(0)
+        return None
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config["DEBUG"] = True
+    # SECRET_KEY generated using: secrets.token_urlsafe()
+    app.config["SECRET_KEY"] = "pf9Wkove4IKEAXvy-cQkeDPhv9Cb3Ag-wyJILbq_dFw"
+    # PASSWORD_SALT secrets.SystemRandom().getrandbits(128)
+    app.config["SECURITY_PASSWORD_SALT"] = "156043940537155509276282232127182067465"
+
+    # We aren't interested in form-based APIs - so no need for flashing.
+    app.config["SECURITY_FLASH_MESSAGES"] = False
+
+    # Allow signing in with a phone number or email
+    app.config["SECURITY_USER_IDENTITY_ATTRIBUTES"] = ["email", "us_phone_number"]
+    app.config["SECURITY_US_ENABLED_METHODS"] = ["password", "email", "sms"]
+
+    app.config["SECURITY_TOTP_SECRETS"] = {
+        "1": "TjQ9Qa31VOrfEzuPy4VHQWPCTmRzCnFzMKLxXYiZu9B"
+    }
+
+    # These need to be defined to handle redirects
+    # As defined in the API documentation - they will receive the relevant context
+    app.config["SECURITY_LOGIN_ERROR_VIEW"] = "/redir/login-error"
+    app.config["SECURITY_POST_CONFIRM_VIEW"] = "/redir/confirmed"
+    app.config["SECURITY_CONFIRM_ERROR_VIEW"] = "/redir/confirm-error"
+    app.config["SECURITY_RESET_VIEW"] = "/redir/reset-password"
+    app.config["SECURITY_RESET_ERROR_VIEW"] = "/redir/reset-password-error"
+    app.config["SECURITY_REDIRECT_BEHAVIOR"] = "spa"
+
+    # CSRF protection is critical for all session-based browser UIs
+    # In general, most applications don't need CSRF on unauthenticated endpoints
+    app.config["SECURITY_CSRF_IGNORE_UNAUTH_ENDPOINTS"] = True
+
+    # Send Cookie with csrf-token. This is the default for Axios and Angular.
+    app.config["SECURITY_CSRF_COOKIE"] = {"key": "XSRF-TOKEN"}
+    app.config["WTF_CSRF_CHECK_DEFAULT"] = False
+    app.config["WTF_CSRF_TIME_LIMIT"] = None
+
+    # This means the first 'fresh-required' endpoint after login will always require
+    # re-verification - but after that the grace period will kick in.
+    # This isn't likely something a normal app would need/want to do.
+    app.config["SECURITY_FRESHNESS"] = datetime.timedelta(minutes=0)
+    app.config["SECURITY_FRESHNESS_GRACE_PERIOD"] = datetime.timedelta(minutes=2)
+
+    # As of Flask-SQLAlchemy 2.4.0 it is easy to pass in options directly to the
+    # underlying engine. This option makes sure that DB connections from the pool
+    # are still valid. Important for entire application since many DBaaS options
+    # automatically close idle connections.
+    app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {"pool_pre_ping": True}
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+
+    # Initialize a fake SMS service that captures SMS messages
+    app.config["SECURITY_SMS_SERVICE"] = "capture"
+    SmsSenderFactory.senders["capture"] = SmsCaptureSender
+
+    # Turn on all features (except passwordless since that removes normal login)
+    for opt in [
+        "changeable",
+        "recoverable",
+        "registerable",
+        "trackable",
+        "confirmable",
+        "two_factor",
+        "unified_signin",
+    ]:
+        app.config["SECURITY_" + opt.upper()] = True
+
+    if os.environ.get("SETTINGS"):
+        # Load settings from a file pointed to by SETTINGS
+        app.config.from_envvar("SETTINGS")
+
+    # Initialize standard Flask extensions
+    CaptureMail(app)
+    # Enable CSRF on all api endpoints.
+    CSRFProtect(app)
+    db.init_app(app)
+    app.json_encoder = JSONEncoder
+    # Setup Flask-Security
+    Security(app, user_datastore)
+
+    # Init our API
+    from api import api
+
+    app.register_blueprint(api, url_prefix="/api")
+
+    @app.before_first_request
+    def init_db():
+        db.create_all()
+
+    return app
+
+
+if __name__ == "__main__":
+    create_app().run(port=5002)

--- a/examples/unified_signin/server/models.py
+++ b/examples/unified_signin/server/models.py
@@ -1,0 +1,34 @@
+"""
+Copyright 2019 by J. Christopher Wagner (jwag). All rights reserved.
+:license: MIT, see LICENSE for more details.
+
+"""
+
+from flask_security.models import fsqla_v2 as fsqla
+from flask_security import SQLAlchemyUserDatastore
+from flask_sqlalchemy import SQLAlchemy
+
+# Create database connection object
+db = SQLAlchemy()
+
+# Define models
+fsqla.FsModels.set_db_info(db)
+
+
+class Role(db.Model, fsqla.FsRoleMixin):
+    pass
+
+
+class User(db.Model, fsqla.FsUserMixin):
+    blogs = db.relationship("Blog", backref="user", lazy="dynamic")
+    pass
+
+
+class Blog(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    text = db.Column(db.UnicodeText)
+
+
+# Setup Flask-Security
+user_datastore = SQLAlchemyUserDatastore(db, User, Role)

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -3,7 +3,7 @@
     flask_security.unified_signin
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    Flask-Security Unified signin module
+    Flask-Security Unified Signin module
 
     :copyright: (c) 2019-2020 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
@@ -17,7 +17,6 @@
     - should we support a way that /logout redirects to us-signin rather than /login?
     - we should be able to add a phone number as part of setup even w/o any METHODS -
       i.e. to allow login with any identity (phone) and a password.
-    - add new example?
     - add username as last IDENTITY_MAPPING and allow anything...?? or just in example?
 
     Consider/Questions:

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -21,7 +21,7 @@ import warnings
 from contextlib import contextmanager
 from datetime import timedelta
 
-from flask import _request_ctx_stack, current_app, flash, request, session, url_for
+from flask import _request_ctx_stack, current_app, flash, g, request, session, url_for
 from flask.json import JSONEncoder
 from flask.signals import message_flashed
 from flask_login import login_user as _login_user
@@ -159,6 +159,9 @@ def logout_user():
     csrf_field_name = find_csrf_field_name()
     if csrf_field_name:
         session.pop(csrf_field_name, None)
+        # Flask-WTF 'caches' csrf_token - and only set the session if not already
+        # in 'g'. Be sure to clear both. This affects at least /confirm
+        g.pop(csrf_field_name, None)
     session["fs_cc"] = "clear"
     identity_changed.send(
         current_app._get_current_object(), identity=AnonymousIdentity()


### PR DESCRIPTION
This adds a server/client example using JSON to register and us-setup a new user.

Uncovered a bug that after registration/confirmation - the CSRF token in the session wasn't
properly set. That has been fixed.