### PR TITLE
Add config such that /us-signin becomes the default for /login.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -263,6 +263,10 @@ These configuration keys are used globally across all features.
 
     Default: ``['email']``.
 
+    .. danger::
+        Make sure that any attributes listed here are marked Unique in your UserDataStore
+        model.
+
 .. py:data:: SECURITY_USER_IDENTITY_MAPPINGS
 
     Defines the order and matching that will be applied when validating the
@@ -277,12 +281,8 @@ These configuration keys are used globally across all features.
             {"us_phone_number": uia_phone_mapper},
         ],
 
-    Be aware that ONLY those attributes listed in ``SECURITY_USER_IDENTITY_ATTRIBUTES``
+    Be aware that ONLY those attributes listed in :py:data:`SECURITY_USER_IDENTITY_ATTRIBUTES`
     will be considered - regardless of the setting of this variable.
-
-    .. danger::
-        Make sure that any columns listed here are marked Unique in your UserDataStore
-        model.
 
     .. versionadded:: 3.4.0
 
@@ -995,6 +995,13 @@ Unified Signin
     token expires. Always pluralize the time unit for this value.
 
     Default: "30 minutes"
+
+.. py:data:: SECURITY_US_SIGNIN_REPLACES_LOGIN
+
+    If set, then the :py:data:`SECURITY_LOGIN_URL` will be registered to the ``us-signin`` endpoint.
+    Doing this will mean that logout will properly redirect to the us-signin endpoint.
+
+    Default: ``False``
 
 
 Additional relevant configuration variables:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -814,9 +814,9 @@ paths:
                   methods:
                     type: string
                     description: Config setting SECURITY_US_ENABLED_METHODS
-                  code_methods:
+                  setup_methods:
                     type: string
-                    description: All SECURITY_US_ENABLED_METHODS that require a code to be generated and sent.
+                    description: All SECURITY_US_ENABLED_METHODS that require setup.
                   identity_attributes:
                     type: string
                     description: Configuration setting SECURITY_USER_IDENTITY_ATTRIBUTES

--- a/examples/unified_signin/server/models.py
+++ b/examples/unified_signin/server/models.py
@@ -20,7 +20,8 @@ class Role(db.Model, fsqla.FsRoleMixin):
 
 
 class User(db.Model, fsqla.FsUserMixin):
-    blogs = db.relationship("Blog", backref="user", lazy="dynamic")
+    # Because we set "us_phone_number" as a USER_IDENTITY - it must be unique
+    us_phone_number = db.Column(db.String(128), unique=True, nullable=True)
     pass
 
 

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -266,6 +266,7 @@ _default_config = {
     "US_TOKEN_VALIDITY": 120,
     "US_EMAIL_SUBJECT": _("Verification Code"),
     "US_SETUP_WITHIN": "30 minutes",
+    "US_SIGNIN_REPLACES_LOGIN": False,
     "CSRF_PROTECT_MECHANISMS": AUTHN_MECHANISMS,
     "CSRF_IGNORE_UNAUTH_ENDPOINTS": False,
     "CSRF_COOKIE": {"key": None},

--- a/flask_security/templates/security/us_setup.html
+++ b/flask_security/templates/security/us_setup.html
@@ -7,7 +7,7 @@
     <form action="{{ url_for_security("us_setup") }}" method="POST"
           name="us_setup_form">
       {{ us_setup_form.hidden_tag() }}
-      {% if code_methods %}
+      {% if setup_methods %}
         {{ render_field_with_errors(us_setup_form.new_totp_secret) }}
         {% for subfield in us_setup_form.chosen_method %}
           {% if subfield.data in methods %}
@@ -27,7 +27,7 @@
         {% endif %}
         {{ render_field(us_setup_form.submit) }}
       {% else %}
-        <h3>{{  _("No code methods have been enabled - nothing to setup") }}</h3>
+        <h3>{{  _("No methods have been enabled - nothing to setup") }}</h3>
       {% endif %}
     </form>
     {%  if state %}

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -1078,6 +1078,8 @@ def create_blueprint(app, state, import_name, json_encoder=None):
             state.login_url + slash_url_suffix(state.login_url, "<token>"),
             endpoint="token_login",
         )(token_login)
+    elif config_value("US_SIGNIN_REPLACES_LOGIN", app=app):
+        bp.route(state.login_url, methods=["GET", "POST"], endpoint="login")(us_signin)
 
     else:
         bp.route(state.login_url, methods=["GET", "POST"], endpoint="login")(login)

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -63,23 +63,21 @@ def create_app():
     app.config["DEBUG"] = True
     # SECRET_KEY generated using: secrets.token_urlsafe()
     app.config["SECRET_KEY"] = "pf9Wkove4IKEAXvy-cQkeDPhv9Cb3Ag-wyJILbq_dFw"
+    # PASSWORD_SALT secrets.SystemRandom().getrandbits(128)
+    app.config["SECURITY_PASSWORD_SALT"] = "156043940537155509276282232127182067465"
+
     app.config["LOGIN_DISABLED"] = False
     app.config["WTF_CSRF_ENABLED"] = False
     app.config["SECURITY_USER_IDENTITY_ATTRIBUTES"] = ["email", "us_phone_number"]
     # app.config["SECURITY_US_ENABLED_METHODS"] = ["password"]
     # app.config["SECURITY_US_ENABLED_METHODS"] = ["authenticator", "password"]
+    # app.config["SECURITY_US_SIGNIN_REPLACES_LOGIN"] = True
 
     app.config["SECURITY_TOTP_SECRETS"] = {
         "1": "TjQ9Qa31VOrfEzuPy4VHQWPCTmRzCnFzMKLxXYiZu9B"
     }
     app.config["SECURITY_FRESHNESS"] = datetime.timedelta(minutes=5)
     app.config["SECURITY_FRESHNESS_GRACE_PERIOD"] = datetime.timedelta(minutes=2)
-
-    # Make this plaintext for most tests - reduces unit test time by 50%
-    app.config["SECURITY_PASSWORD_HASH"] = "plaintext"
-    # Make this hex_md5 for token tests
-    app.config["SECURITY_HASHING_SCHEMES"] = ["hex_md5"]
-    app.config["SECURITY_DEPRECATED_HASHING_SCHEMES"] = []
 
     # Turn on all features (except passwordless since that removes normal login)
     for opt in [


### PR DESCRIPTION
Fixed over-zealous form handling that didn't allow "authenticator" to be setup!

For unified sign in example - since we claim us_phone_number can be used as an identity, we need to
make that column unique in the model..