### PR TITLE
Generate new totp secret on each setup

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1170,9 +1170,6 @@ components:
         chosen_method:
           type: string
           description: which method should be used to send the code, as configured with SECURITY_US_ENABLED_METHODS
-        new_totp_secret:
-          type: boolean
-          description: if set to True a new totp secret for the chosen method will be generated. This will for example invalidate prior codes and authenticator setup.
         phone:
           type: string
           description: phone number (this will be normalized)

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -1052,7 +1052,7 @@ class Security(object):
         ``verify_form`` added as part of freshness/re-authentication
 
     .. versionchanged:: 3.4.0
-        ``us_signin_form``, ``us_setup_form``, ``us_setup_verify_form``
+        ``us_signin_form``, ``us_setup_form``, ``us_setup_verify_form``, and
         ``us_verify_form`` added as part of the :ref:`unified-sign-in` feature.
 
     .. versionchanged:: 3.4.0

--- a/flask_security/templates/security/us_setup.html
+++ b/flask_security/templates/security/us_setup.html
@@ -8,7 +8,6 @@
           name="us_setup_form">
       {{ us_setup_form.hidden_tag() }}
       {% if setup_methods %}
-        {{ render_field_with_errors(us_setup_form.new_totp_secret) }}
         {% for subfield in us_setup_form.chosen_method %}
           {% if subfield.data in methods %}
               {{ render_field_with_errors(subfield) }}


### PR DESCRIPTION
Remove the user/form option to generate a new totp. Since we have a different
totp per method, we can just change it on each new method setup. This is much safer and follows
what was done for two-factor.