### PR TITLE
Fixes to us sign in

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -286,6 +286,20 @@ These configuration keys are used globally across all features.
     Be aware that ONLY those attributes listed in :py:data:`SECURITY_USER_IDENTITY_ATTRIBUTES`
     will be considered - regardless of the setting of this variable.
 
+    Mapping functions take a single argument - ``identity`` from the form
+    and should return ``None`` if the ``identity`` argument isn't in a format
+    suitable for the attribute. If the ``identity`` argument format matches, it
+    should be returned, optionally having had some canonicalization performed.
+    The returned result will be used to look up the identity in the UserDataStore.
+
+    The provided :meth:`flask_security.uia_phone_mapper` for example performs
+    phone number normalization using the ``phonenumbers`` package.
+
+    .. tip::
+        If your mapper performs any sort of canonicalization/normalization,
+        make sure you apply the exact same transformation in your form validator
+        when setting the field.
+
     .. versionadded:: 3.4.0
 
 .. py:data:: SECURITY_DEFAULT_REMEMBER_ME
@@ -329,7 +343,8 @@ These are used by the Two-Factor and Unified Signin features.
 
     .. code-block:: python
 
-        "{1: <result of passlib.totp.generate_secret()>}"
+        from passlib import totp
+        "{1: <result of totp.generate_secret()>}"
 
     See: `Totp`_ for details.
 
@@ -340,7 +355,7 @@ These are used by the Two-Factor and Unified Signin features.
     Specifies the name of the service or application that the user is authenticating to.
     This will be the name displayed by most authenticator apps.
 
-    Default: ``service_name``.
+    Default: ``None``.
 
     .. versionadded:: 3.4.0
 

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -122,7 +122,7 @@ The following is a list of all the available form overrides:
 * ``two_factor_rescue_form``: Two-factor help user form
 * ``us_signin_form``: Unified sign in form
 * ``us_setup_form``: Unified sign in setup form
-* ``us_setup_verify_form``: Unified sign in setup verify form
+* ``us_setup_validate_form``: Unified sign in setup validation form
 
 .. tip::
     Changing/extending the form class won't directly change how it is displayed.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -564,7 +564,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  methods:
+                  available_methods:
                     type: string
                     description: Config setting SECURITY_US_ENABLED_METHODS
                   code_methods:
@@ -694,7 +694,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  methods:
+                  available_methods:
                     type: string
                     description: Config setting SECURITY_US_ENABLED_METHODS
                   code_methods:
@@ -811,9 +811,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  methods:
+                  available_methods:
                     type: string
                     description: Config setting SECURITY_US_ENABLED_METHODS
+                  active_methods:
+                    type: string
+                    description: Methods that have already been setup.
                   setup_methods:
                     type: string
                     description: All SECURITY_US_ENABLED_METHODS that require setup.
@@ -868,7 +871,7 @@ paths:
         schema:
           type: string
     get:
-      summary: Verify unified sign in setup request.
+      summary: Validate unified sign in setup request.
       description: >
         This does nothing but redirect back to the setup form.
       responses:
@@ -880,16 +883,25 @@ paths:
                 example: render_template(SECURITY_US_SETUP_TEMPLATE)
               
     post:
-      summary: Verify code sent and store setup method.
+      summary: Validate passcode sent and store setup method.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UsSetupValidateRequest"
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/UsSetupValidateRequest"
       responses:
         200:
-          description: Successfully verifed and setup sign in method.
+          description: Successfully validated and persisted sign in method.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UsSetupVerifyJsonResponse"
+                $ref: "#/components/schemas/UsSetupValidateJsonResponse"
         302:
-          description: Successfuly verified and setup sign in method.
+          description: Successfuly validated and persisted sign in method.
           headers:
             Location:
               description: |
@@ -897,6 +909,12 @@ paths:
                                  SECURITY_POST_LOGIN_VIEW
               schema:
                 type: string
+        400:
+          description: Validation failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DefaultJsonErrorResponse"
   /us-verify-link:
     parameters:
       - name: email
@@ -1172,7 +1190,7 @@ components:
           description: which method should be used to send the code, as configured with SECURITY_US_ENABLED_METHODS
         phone:
           type: string
-          description: phone number (this will be normalized)
+          description: phone number (this will be normalized). Required if chosen_method == "sms".
     UsSetupJsonResponse:
       type: object
       required: [meta, response]
@@ -1193,8 +1211,15 @@ components:
               description: The chosen_method as passed into API.
             state:
               type: string
-              description: Opaque blob that must be pass to /us-setup-verify. This is a signed, timed token.
-    UsSetupVerifyJsonResponse:
+              description: Opaque blob that must be pass to /us-setup/<state>. This is a signed, timed token.
+    UsSetupValidateRequest:
+      type: object
+      required: [passcode]
+      properties:
+        passcode:
+          type: string
+          description: Code/Passcode as received from method being setup.
+    UsSetupValidateJsonResponse:
       type: object
       required: [meta, response]
       properties:

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -72,7 +72,7 @@ from .twofactor import tf_send_security_token
 from .unified_signin import (
     UnifiedSigninForm,
     UnifiedSigninSetupForm,
-    UnifiedSigninSetupVerifyForm,
+    UnifiedSigninSetupValidateForm,
     UnifiedVerifyForm,
     us_send_security_token,
 )

--- a/flask_security/templates/security/us_setup.html
+++ b/flask_security/templates/security/us_setup.html
@@ -9,12 +9,12 @@
       {{ us_setup_form.hidden_tag() }}
       {% if setup_methods %}
         {% for subfield in us_setup_form.chosen_method %}
-          {% if subfield.data in methods %}
+          {% if subfield.data in available_methods %}
               {{ render_field_with_errors(subfield) }}
           {% endif %}
         {% endfor %}
         {{ render_field_errors(us_setup_form.chosen_method) }}
-        {% if "sms" in methods %}
+        {% if "sms" in available_methods %}
           {{ render_field_with_errors(us_setup_form.phone) }}
         {% endif %}
         {% if chosen_method == "authenticator" %}
@@ -30,11 +30,11 @@
       {% endif %}
     </form>
     {%  if state %}
-      <form action="{{ url_for_security("us_setup_verify", token=state) }}" method="POST"
-          name="us_setup_verify_form">
-        {{ us_setup_verify_form.hidden_tag() }}
-        {{ render_field_with_errors(us_setup_verify_form.code) }}
-        {{ render_field(us_setup_verify_form.submit) }}
+      <form action="{{ url_for_security("us_setup_validate", token=state) }}" method="POST"
+          name="us_setup_validate_form">
+        {{ us_setup_validate_form.hidden_tag() }}
+        {{ render_field_with_errors(us_setup_validate_form.passcode) }}
+        {{ render_field(us_setup_validate_form.submit) }}
       </form>
     {%  endif %}
 {% endblock %}

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -61,7 +61,7 @@ from .unified_signin import (
     us_signin_send_code,
     us_qrcode,
     us_setup,
-    us_setup_verify,
+    us_setup_validate,
     us_verify,
     us_verify_link,
     us_verify_send_code,
@@ -1101,8 +1101,8 @@ def create_blueprint(app, state, import_name, json_encoder=None):
         bp.route(
             state.us_setup_url + slash_url_suffix(state.us_setup_url, "<token>"),
             methods=["GET", "POST"],
-            endpoint="us_setup_verify",
-        )(us_setup_verify)
+            endpoint="us_setup_validate",
+        )(us_setup_validate)
 
         # Freshness verification
         if config_value("FRESHNESS", app=app).total_seconds() >= 0:

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -71,6 +71,7 @@ def create_app():
     app.config["SECURITY_USER_IDENTITY_ATTRIBUTES"] = ["email", "us_phone_number"]
     # app.config["SECURITY_US_ENABLED_METHODS"] = ["password"]
     # app.config["SECURITY_US_ENABLED_METHODS"] = ["authenticator", "password"]
+
     # app.config["SECURITY_US_SIGNIN_REPLACES_LOGIN"] = True
 
     app.config["SECURITY_TOTP_SECRETS"] = {


### PR DESCRIPTION
Changed name of setup verify form to setup validate form - too many other things are called validate.

Fixed bug in _us_common_validate - despite what the comments said - it didn't exit after first match.

Fixed bugs in startup config checking - if not SMS don't require phonenumbers.

Changed default fot TOTP_ISSUER to None - folks really need to set that otherwise authenticator apps look silly.

Add more documentation about SECURITY_IDENTITY_MAPPINGS

Change methods to available_methods in us-sign in API everywhere.

Added active_methods value to return in us-setup so that UIs can display that if they want.